### PR TITLE
Push dev versions to ECR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,15 +83,16 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write  # Required for AWS OIDC login
 
     uses: "posit-dev/images-shared/.github/workflows/bakery-build.yml@main"
     secrets:
+      AWS_ROLE: ${{ secrets.AWS_ROLE }}
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
     with:
       runs-on: ubuntu-latest-4x
       dev-versions: "only"
+      aws-region: us-west-2
       # Push images only for merges into main and hourly schduled re-builds.
-      # TODO: Override image registry before enabling pushing
-      # push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event.schedule == '45 4 * * *' }}
-      push: false
+      push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event.schedule == '45 4 * * *' }}

--- a/bakery.yaml
+++ b/bakery.yaml
@@ -57,6 +57,9 @@ images:
         os:
           - name: Ubuntu 22.04
             primary: true
+        overrideRegistries:
+          - host: "749683154838.dkr.ecr.us-west-2.amazonaws.com"
+            repository: "workbench-preview"
     versions:
       - name: 2025.09.2+418.pro4
         subpath: '2025.09'
@@ -100,6 +103,9 @@ images:
         os:
           - name: Ubuntu 22.04
             primary: true
+        overrideRegistries:
+          - host: "749683154838.dkr.ecr.us-west-2.amazonaws.com"
+            repository: "workbench-session-init-preview"
         values:
           go_version: 1.25.3
     versions:


### PR DESCRIPTION
Push Dev versions to ECR. Requires AWS credentials
