### PR TITLE
Test bakery cache-tag branch

### DIFF
--- a/.github/workflows/product.yml
+++ b/.github/workflows/product.yml
@@ -60,10 +60,11 @@ jobs:
       contents: read
       packages: write
 
-    uses: "posit-dev/images-shared/.github/workflows/bakery-build.yml@main"
+    uses: "posit-dev/images-shared/.github/workflows/bakery-build.yml@cache-tag"
     secrets:
       DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
     with:
+      version: "cache-tag"
       runs-on: ubuntu-latest-4x
       dev-versions: "exclude"
       matrix-versions: "exclude"
@@ -84,10 +85,11 @@ jobs:
       packages: write
       id-token: write  # Required for AWS OIDC login
 
-    uses: "posit-dev/images-shared/.github/workflows/bakery-build.yml@main"
+    uses: "posit-dev/images-shared/.github/workflows/bakery-build.yml@cache-tag"
     secrets:
       AWS_ROLE: ${{ secrets.AWS_ROLE }}
     with:
+      version: "cache-tag"
       runs-on: ubuntu-latest-4x
       dev-versions: "only"
       matrix-versions: "exclude"

--- a/.github/workflows/session.yml
+++ b/.github/workflows/session.yml
@@ -30,10 +30,11 @@ jobs:
       contents: read
       packages: write
 
-    uses: "posit-dev/images-shared/.github/workflows/bakery-build.yml@main"
+    uses: "posit-dev/images-shared/.github/workflows/bakery-build.yml@cache-tag"
     secrets:
       DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
     with:
+      version: "cache-tag"
       runs-on: ubuntu-latest-4x
       matrix-versions: only
       # Push images only for merges into main and weekly schduled re-builds.


### PR DESCRIPTION
## Summary
- Points build workflows at the `images-shared` `cache-tag` branch to test improved cache tag generation
- Adds `version: "cache-tag"` to install bakery from the feature branch
- Cache tags now include platform suffixes for single-platform builds and preserve version pre-release identifiers

## Test plan
- [ ] Verify CI builds complete successfully
- [ ] Inspect generated cache tags in build logs for correctness
- [ ] Confirm no cache collisions between OS/variant/platform combinations

> **Note:** Revert to `@main` before merging. This PR is for testing only.