### PR TITLE
Disable jupyter notebook in Workbench image

### DIFF
--- a/workbench/2024.12/conf/jupyter/jupyter.conf
+++ b/workbench/2024.12/conf/jupyter/jupyter.conf
@@ -1,3 +1,2 @@
-notebooks-enabled=1
 labs-enabled=1
 default-session-cluster=Local

--- a/workbench/2025.05/conf/jupyter/jupyter.conf
+++ b/workbench/2025.05/conf/jupyter/jupyter.conf
@@ -1,3 +1,2 @@
-notebooks-enabled=1
 labs-enabled=1
 default-session-cluster=Local

--- a/workbench/2025.09/conf/jupyter/jupyter.conf
+++ b/workbench/2025.09/conf/jupyter/jupyter.conf
@@ -1,3 +1,2 @@
-notebooks-enabled=1
 labs-enabled=1
 default-session-cluster=Local

--- a/workbench/2026.01/conf/jupyter/jupyter.conf
+++ b/workbench/2026.01/conf/jupyter/jupyter.conf
@@ -1,3 +1,2 @@
-notebooks-enabled=1
 labs-enabled=1
 default-session-cluster=Local

--- a/workbench/template/conf/jupyter/jupyter.conf.jinja2
+++ b/workbench/template/conf/jupyter/jupyter.conf.jinja2
@@ -1,3 +1,2 @@
-notebooks-enabled=1
 labs-enabled=1
 default-session-cluster=Local


### PR DESCRIPTION
Notebook was disabled in Marketplaces a while ago. I think it can safely be removed in new images for Lab.