### PR TITLE
Default `TARGETARCH` to `BUILDARCH` in workbench-positron-init

### DIFF
--- a/workbench-positron-init/template/Containerfile.ubuntu2404.jinja2
+++ b/workbench-positron-init/template/Containerfile.ubuntu2404.jinja2
@@ -6,7 +6,8 @@ Bakery handles bootstrapping the files into template rendering.
 FROM docker.io/library/ubuntu:24.04 AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG TARGETARCH
+ARG BUILDARCH
+ARG TARGETARCH=${BUILDARCH}
 ARG POSITRON_VERSION
 
 {{ apt.run_setup() }}


### PR DESCRIPTION
This fixes an edge case where `TARGETARCH` is unset if `--platform` is not explicitly passed to a build.