### PR TITLE
Fix broken pipx link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Additional documentation:
 Build prerequisites
 
 * [python](https://docs.astral.sh/uv/guides/install-python/)
-* [pipx](https://pipx.pypa.io/stable/installation/)
+* [pipx](https://pipx.pypa.io/stable/how-to/install-pipx/)
 * [docker buildx bake](https://github.com/docker/buildx#installing)
 * [just](https://just.systems/man/en/prerequisites.html)
 * [gh](https://github.com/cli/cli#installation) (required while repositories are private)


### PR DESCRIPTION
## Summary
- Fix pipx installation URL (moved to `/how-to/install-pipx/`)