### PR TITLE
Replace pipx with uv tool install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,12 +107,9 @@ ipython_config.py
 #   install all needed dependencies.
 #Pipfile.lock
 
-# poetry
-#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-#poetry.lock
+# uv
+#   https://docs.astral.sh/uv/concepts/projects/layout/#the-lockfile
+#uv.lock
 
 # pdm
 #   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Additional documentation:
 Build prerequisites
 
 * [python](https://docs.astral.sh/uv/guides/install-python/)
-* [pipx](https://pipx.pypa.io/stable/how-to/install-pipx/)
+* [uv](https://docs.astral.sh/uv/getting-started/installation/)
 * [docker buildx bake](https://github.com/docker/buildx#installing)
 * [just](https://just.systems/man/en/prerequisites.html)
 * [gh](https://github.com/cli/cli#installation) (required while repositories are private)

--- a/justfile
+++ b/justfile
@@ -3,7 +3,7 @@
 install-bakery *OPTS:
   #!/bin/bash
   # TODO: Update this after package is published somewhere
-  pipx install {{OPTS}} 'git+ssh://git@github.com/posit-dev/images-shared.git@main#egg=posit-bakery&subdirectory=posit-bakery'
+  uv tool install {{OPTS}} 'git+ssh://git@github.com/posit-dev/images-shared.git@main#egg=posit-bakery&subdirectory=posit-bakery'
 
 install-goss:
   #!/bin/bash


### PR DESCRIPTION
## Summary
- Replace `pipx install` with `uv tool install` in the justfile
- Update README build prerequisites to link to uv instead of pipx

## Test plan
- [x] Verify `just install-bakery` works with `uv tool install`