### PR TITLE
Push preview images to GHCR instead of ECR

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -45,16 +45,12 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write  # Required for AWS OIDC login
 
     uses: "posit-dev/images-shared/.github/workflows/bakery-build.yml@main"
-    secrets:
-      AWS_ROLE: ${{ secrets.AWS_ROLE }}
     with:
       runs-on: ubuntu-latest-4x
       dev-versions: "only"
       matrix-versions: "exclude"
-      aws-region: us-west-2
       # Push images only for merges into main and hourly schduled re-builds.
       push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' }}
 

--- a/bakery.yaml
+++ b/bakery.yaml
@@ -59,7 +59,8 @@ images:
             primary: true
           - name: Ubuntu 22.04
         overrideRegistries:
-          - host: "749683154838.dkr.ecr.us-west-2.amazonaws.com"
+          - host: "ghcr.io"
+            namespace: "posit-dev"
             repository: "workbench-preview"
     versions:
       - name: 2026.01.1+403.pro11
@@ -97,7 +98,8 @@ images:
           - name: Ubuntu 24.04
             primary: true
         overrideRegistries:
-          - host: "749683154838.dkr.ecr.us-west-2.amazonaws.com"
+          - host: "ghcr.io"
+            namespace: "posit-dev"
             repository: "workbench-session-init-preview"
     versions:
       - name: 2026.01.1+403.pro11


### PR DESCRIPTION
## Summary
- Replace internal ECR override registries with `ghcr.io/posit-dev` for `workbench-preview` and `workbench-session-init-preview` dev version images
- Remove AWS OIDC permission (`id-token: write`), `AWS_ROLE` secret, and `aws-region` input from the development workflow
- Aligns with the pattern already used by `images-connect`

## Test plan
- [ ] Verify the development workflow CI passes on this PR (build without push)
- [ ] After merge, confirm scheduled/push builds push to `ghcr.io/posit-dev/workbench-preview` and `ghcr.io/posit-dev/workbench-session-init-preview`