### PR TITLE
Add workflow_dispatch trigger and update-helm job

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -31,6 +31,7 @@ jobs:
     timeout-minutes: 10
     needs:
       - build
+      - update-helm
 
     steps:
       - uses: re-actors/alls-green@release/v1
@@ -94,11 +95,12 @@ jobs:
       - name: Dispatch Helm update
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_VERSION: ${{ steps.version.outputs.app-version }}
         run: |
           gh workflow run product-release.yml \
             --repo rstudio/helm \
             --field product=workbench \
-            --field app-version=${{ steps.version.outputs.app-version }}
+            --field app-version="$APP_VERSION"
 
   clean:
     name: Clean

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,5 +1,7 @@
 name: Production
 on:
+  workflow_dispatch:
+
   schedule:
     # Weekly rebuild of all images, to pick up any upstream changes.
     - cron: "15 3 * * 0" # At 03:15 on Sunday
@@ -34,6 +36,7 @@ jobs:
       - uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
+          allowed-skips: update-helm
 
   build:
     name: Build
@@ -55,8 +58,47 @@ jobs:
       runs-on: ubuntu-latest-4x
       dev-versions: "exclude"
       matrix-versions: "exclude"
-      # Push images only for merges into main and weekly schduled re-builds.
-      push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' }}
+      push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+
+  update-helm:
+    name: Update Helm
+    if: ${{ needs.build.result == 'success' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') }}
+    needs:
+      - build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install bakery
+        uses: posit-dev/images-shared/setup-bakery@main
+
+      - name: Get latest version
+        id: version
+        run: |
+          APP_VERSION=$(bakery get version workbench)
+          # Strip build metadata for helm appVersion (e.g. 2026.01.1+403.pro11 → 2026.01.1)
+          APP_VERSION="${APP_VERSION%%+*}"
+          echo "app-version=$APP_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: rstudio
+          repositories: helm
+
+      - name: Dispatch Helm update
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh workflow run product-release.yml \
+            --repo rstudio/helm \
+            --field product=workbench \
+            --field app-version=${{ steps.version.outputs.app-version }}
 
   clean:
     name: Clean


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` trigger to `production.yml` for manual rebuild+push
- Add `update-helm` job that dispatches `product-release.yml` in `rstudio/helm` after successful builds on push to main or manual dispatch
- Uses `bakery get version` to read the latest version, strips build metadata suffix for helm

## Test plan

- [ ] Verify `workflow_dispatch` trigger works for manual rebuilds
- [ ] Verify `update-helm` job is skipped on PRs and scheduled builds
- [ ] Verify version stripping: `2026.01.1+403.pro11` → `2026.01.1`
- [ ] Verify CI gate job passes with `update-helm` in `allowed-skips`