### PR TITLE
Remove duplicate Quarto+TinyTeX install

### DIFF
--- a/workbench-session/matrix/Containerfile.ubuntu2204
+++ b/workbench-session/matrix/Containerfile.ubuntu2204
@@ -60,15 +60,8 @@ RUN RUN_UNATTENDED=1 R_VERSION=$R_VERSION bash -c "$(curl -fsSL https://rstd.io/
     find . -type f -name '[rR]-$R_VERSION.*\.(deb|rpm)' -delete
 
 ### Install Quarto and TinyTeX ###
-# Caches won't invalidate correctly on new releases for TinyTeX installs. This ADD instruction is a workaround to bust
-# the cache on new releases.
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
-    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v$QUARTO_VERSION/quarto-$QUARTO_VERSION-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/$QUARTO_VERSION" --strip-components=1 && \
-    /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet \
-    && rm -f /tmp/tinytex-release.json
-
-### Install Quarto and TinyTeX ###
+# Caches won't invalidate correctly on new releases for TinyTeX installs.
+# This ADD instruction is a workaround to bust the cache on new releases.
 ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
     curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v$QUARTO_VERSION/quarto-$QUARTO_VERSION-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/$QUARTO_VERSION" --strip-components=1 && \

--- a/workbench-session/matrix/Containerfile.ubuntu2404
+++ b/workbench-session/matrix/Containerfile.ubuntu2404
@@ -60,15 +60,8 @@ RUN RUN_UNATTENDED=1 R_VERSION=$R_VERSION bash -c "$(curl -fsSL https://rstd.io/
     find . -type f -name '[rR]-$R_VERSION.*\.(deb|rpm)' -delete
 
 ### Install Quarto and TinyTeX ###
-# Caches won't invalidate correctly on new releases for TinyTeX installs. This ADD instruction is a workaround to bust
-# the cache on new releases.
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
-    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v$QUARTO_VERSION/quarto-$QUARTO_VERSION-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/$QUARTO_VERSION" --strip-components=1 && \
-    /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet \
-    && rm -f /tmp/tinytex-release.json
-
-### Install Quarto and TinyTeX ###
+# Caches won't invalidate correctly on new releases for TinyTeX installs.
+# This ADD instruction is a workaround to bust the cache on new releases.
 ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
     curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v$QUARTO_VERSION/quarto-$QUARTO_VERSION-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/$QUARTO_VERSION" --strip-components=1 && \

--- a/workbench-session/template/Containerfile.ubuntu2204.jinja2
+++ b/workbench-session/template/Containerfile.ubuntu2204.jinja2
@@ -44,13 +44,8 @@ RUN {{ python.install_packages(python.build_arg(), "ipykernel") }} && \
 {{ r.run_install(r.build_arg()) }}
 
 ### Install Quarto and TinyTeX ###
-# Caches won't invalidate correctly on new releases for TinyTeX installs. This ADD instruction is a workaround to bust
-# the cache on new releases.
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-{{ quarto.run_install(quarto.build_arg(), True) }} \
-    && rm -f /tmp/tinytex-release.json
-
-### Install Quarto and TinyTeX ###
+# Caches won't invalidate correctly on new releases for TinyTeX installs.
+# This ADD instruction is a workaround to bust the cache on new releases.
 ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN {{ quarto.install(quarto.build_arg(), True, True) | indent(4) }} && \
     {{ quarto.symlink_binary(quarto.build_arg(), "quarto", "/usr/local/bin/quarto") | indent(4) }} && \

--- a/workbench-session/template/Containerfile.ubuntu2404.jinja2
+++ b/workbench-session/template/Containerfile.ubuntu2404.jinja2
@@ -44,13 +44,8 @@ RUN {{ python.install_packages(python.build_arg(), "ipykernel") }} && \
 {{ r.run_install(r.build_arg()) }}
 
 ### Install Quarto and TinyTeX ###
-# Caches won't invalidate correctly on new releases for TinyTeX installs. This ADD instruction is a workaround to bust
-# the cache on new releases.
-ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-{{ quarto.run_install(quarto.build_arg(), True) }} \
-    && rm -f /tmp/tinytex-release.json
-
-### Install Quarto and TinyTeX ###
+# Caches won't invalidate correctly on new releases for TinyTeX installs.
+# This ADD instruction is a workaround to bust the cache on new releases.
 ADD https://api.github.com/repos/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN {{ quarto.install(quarto.build_arg(), True, True) | indent(4) }} && \
     {{ quarto.symlink_binary(quarto.build_arg(), "quarto", "/usr/local/bin/quarto") | indent(4) }} && \


### PR DESCRIPTION
## Summary

- Remove duplicate Quarto+TinyTeX install block in workbench-session templates. The first block installed Quarto+TinyTeX without `--update-path` and without a symlink; the second block reinstalled both with `--update-path` and a symlink. The first was entirely redundant.

Addresses posit-dev/images-shared#138.

## Test plan

- [ ] Rendered Containerfiles contain a single Quarto+TinyTeX install block
- [ ] Build workbench-session image and verify Quarto and TinyTeX are installed correctly