### PR TITLE
Add update-helm job to production workflow

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -72,10 +72,14 @@ jobs:
     needs:
       - build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install bakery
         uses: posit-dev/images-shared/setup-bakery@main
@@ -89,12 +93,13 @@ jobs:
 
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
           app-id: ${{ secrets.WORKBENCH_IDE_RELEASE_APP_ID }}
           private-key: ${{ secrets.WORKBENCH_IDE_RELEASE_PEM }}
           owner: rstudio
           repositories: helm
+          permission-actions: write
 
       - name: Dispatch Helm update
         env:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -29,12 +29,14 @@ jobs:
     timeout-minutes: 10
     needs:
       - build
+      - update-helm
 
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # v1.2.2
         id: alls-green
         with:
           jobs: ${{ toJSON(needs) }}
+          allowed-skips: update-helm
       - if: always() && github.ref == 'refs/heads/main'
         continue-on-error: true
         uses: posit-dev/images-shared/.github/actions/slack-build-notify@main
@@ -63,6 +65,46 @@ jobs:
       matrix-versions: "exclude"
       # Push images only for merges into main and weekly schduled re-builds.
       push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
+
+  update-helm:
+    name: Update Helm
+    if: ${{ needs.build.result == 'success' && (github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') }}
+    needs:
+      - build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install bakery
+        uses: posit-dev/images-shared/setup-bakery@main
+
+      - name: Get latest version
+        id: version
+        run: |
+          APP_VERSION=$(bakery get version workbench)
+          APP_VERSION="${APP_VERSION%%[+-]*}"
+          echo "app-version=$APP_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.WORKBENCH_IDE_RELEASE_APP_ID }}
+          private-key: ${{ secrets.WORKBENCH_IDE_RELEASE_PEM }}
+          owner: rstudio
+          repositories: helm
+
+      - name: Dispatch Helm update
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_VERSION: ${{ steps.version.outputs.app-version }}
+        run: |
+          gh workflow run product-release.yml \
+            --repo rstudio/helm \
+            --field product=workbench \
+            --field version="$APP_VERSION"
 
   clean:
     name: Clean


### PR DESCRIPTION
## Summary

- Add `update-helm` job that dispatches `product-release.yml` in `rstudio/helm` after successful production builds
- Strips pre-release/build metadata from app version before dispatching
- Uses the `workbench-ide-release` GitHub App for the dispatch token (`WORKBENCH_IDE_RELEASE_APP_ID` / `WORKBENCH_IDE_RELEASE_PEM`)

## Dependencies

- rstudio/helm#830 — receiver `product-release.yml` workflow
- `workbench-ide-release` App must be installed on `rstudio/helm` with `actions: write` so the dispatch succeeds