### PR TITLE
Add Slack build notifications to CI workflows

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           jobs: ${{ toJSON(needs) }}
       - if: always() && github.ref == 'refs/heads/main'
+        continue-on-error: true
         uses: posit-dev/images-shared/.github/actions/slack-build-notify@main
         with:
           result: ${{ steps.alls-green.outcome }}

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -32,8 +32,14 @@ jobs:
 
     steps:
       - uses: re-actors/alls-green@release/v1
+        id: alls-green
         with:
           jobs: ${{ toJSON(needs) }}
+      - if: always() && github.ref == 'refs/heads/main'
+        uses: posit-dev/images-shared/.github/actions/slack-build-notify@main
+        with:
+          result: ${{ steps.alls-green.outcome }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   dev:
     name: Dev Build

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           jobs: ${{ toJSON(needs) }}
       - if: always() && github.ref == 'refs/heads/main'
+        continue-on-error: true
         uses: posit-dev/images-shared/.github/actions/slack-build-notify@main
         with:
           result: ${{ steps.alls-green.outcome }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -32,8 +32,14 @@ jobs:
 
     steps:
       - uses: re-actors/alls-green@release/v1
+        id: alls-green
         with:
           jobs: ${{ toJSON(needs) }}
+      - if: always() && github.ref == 'refs/heads/main'
+        uses: posit-dev/images-shared/.github/actions/slack-build-notify@main
+        with:
+          result: ${{ steps.alls-green.outcome }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   build:
     name: Build

--- a/.github/workflows/session.yml
+++ b/.github/workflows/session.yml
@@ -31,6 +31,7 @@ jobs:
           jobs: ${{ toJSON(needs) }}
           allowed-skips: clean
       - if: always() && github.ref == 'refs/heads/main'
+        continue-on-error: true
         uses: posit-dev/images-shared/.github/actions/slack-build-notify@main
         with:
           result: ${{ steps.alls-green.outcome }}

--- a/.github/workflows/session.yml
+++ b/.github/workflows/session.yml
@@ -17,6 +17,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  ci:
+    name: CI
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs:
+      - build
+    steps:
+      - uses: re-actors/alls-green@release/v1
+        id: alls-green
+        with:
+          jobs: ${{ toJSON(needs) }}
+          allowed-skips: clean
+      - if: always() && github.ref == 'refs/heads/main'
+        uses: posit-dev/images-shared/.github/actions/slack-build-notify@main
+        with:
+          result: ${{ steps.alls-green.outcome }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   build:
     name: Build


### PR DESCRIPTION
## Summary

- Add Slack notification step to CI meta-jobs in `development.yml` and `production.yml`
- Add CI meta-job (with alls-green + notification) to `session.yml`
- Uses the `slack-build-notify` composite action from posit-dev/images-shared#432

Notifications fire on state transitions only (passing->failing, failing->passing) and include failed job/step details with links.

### Before merge

- [ ] Merge posit-dev/images-shared#432 first
- [ ] Revert action ref from `@worktree-slack-build-notify` to `@main`
- [ ] Add `SLACK_WEBHOOK_URL` repo secret pointing at `#platform-builds-images`

## Test plan

- [ ] Verify notification fires after merge to main
- [ ] Verify no notification on unchanged state