### PR TITLE
Scope clean jobs to match build version filters

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -64,6 +64,7 @@ jobs:
 
     uses: "posit-dev/images-shared/.github/workflows/clean.yml@main"
     with:
+      dev-versions: "only"
       remove-dangling-caches: true
       remove-caches-older-than: 14
       clean-temporary-images: false

--- a/.github/workflows/session.yml
+++ b/.github/workflows/session.yml
@@ -51,9 +51,8 @@ jobs:
 
     uses: "posit-dev/images-shared/.github/workflows/clean.yml@main"
     with:
+      matrix-versions: "only"
       remove-dangling-caches: true
       remove-caches-older-than: 14
-      # FIXME: re-enable temporary image cleanup after moving to native platform workflow
-      # remove-dangling-temporary-images: false
-      # remove-temporary-images-older-than: 3
-      clean-temporary-images: false
+      remove-dangling-temporary-images: false
+      remove-temporary-images-older-than: 3


### PR DESCRIPTION
## Summary

- Development clean passes `dev-versions: "only"`
- Session clean passes `matrix-versions: "only"` and re-enables temp image cleanup (FIXME resolved — already using native workflow)
- Production clean uses defaults (exclude both)

Depends on posit-dev/images-shared#438

## Test plan

- [ ] Development workflow cleanup removes dev image caches
- [ ] Session workflow cleanup removes matrix image caches and temp images