### PR TITLE
Widen positron tarball glob for new naming

### DIFF
--- a/workbench-positron-init/matrix/Containerfile.ubuntu2404
+++ b/workbench-positron-init/matrix/Containerfile.ubuntu2404
@@ -36,7 +36,7 @@ RUN case ${TARGETARCH} in \
     curl -fsSL -o /tmp/positron.tar.gz \
       "https://cdn.posit.co/positron/releases/pwb/${CDN_ARCH}/positron-workbench-linux-${PKG_ARCH}-${POSITRON_VERSION}.tar.gz" && \
     tar -xzf /tmp/positron.tar.gz -C /tmp && \
-    mv /tmp/vscode-reh-web-linux-* /opt/positron/bin/positron-server/bundled && \
+    mv /tmp/vscode-reh-web-*linux-* /opt/positron/bin/positron-server/bundled && \
     rm /tmp/positron.tar.gz && \
     # Download positron docs from CDN
     mkdir -p /opt/positron/docs/positron && \

--- a/workbench-positron-init/template/Containerfile.ubuntu2404.jinja2
+++ b/workbench-positron-init/template/Containerfile.ubuntu2404.jinja2
@@ -31,7 +31,7 @@ RUN case ${TARGETARCH} in \
     curl -fsSL -o /tmp/positron.tar.gz \
       "https://cdn.posit.co/positron/releases/pwb/${CDN_ARCH}/positron-workbench-linux-${PKG_ARCH}-${POSITRON_VERSION}.tar.gz" && \
     tar -xzf /tmp/positron.tar.gz -C /tmp && \
-    mv /tmp/vscode-reh-web-linux-* /opt/positron/bin/positron-server/bundled && \
+    mv /tmp/vscode-reh-web-*linux-* /opt/positron/bin/positron-server/bundled && \
     rm /tmp/positron.tar.gz && \
     # Download positron docs from CDN
     mkdir -p /opt/positron/docs/positron && \


### PR DESCRIPTION
## Summary

- The 2026.04.0-269 Positron release changed the extracted tarball directory from `vscode-reh-web-linux-{arch}` to `vscode-reh-web-pwb-linux-{arch}`, breaking the `mv` glob in the positron-init Containerfile
- Widen the glob from `vscode-reh-web-linux-*` to `vscode-reh-web-*linux-*` to match both naming conventions

## Test plan

- [x] CI builds `workbench-positron-init:2026.04.0-269` successfully on both amd64 and arm64