### PR TITLE
Separate Quarto and TinyTeX install in session images

### DIFF
--- a/workbench-session/matrix/Containerfile.ubuntu2204
+++ b/workbench-session/matrix/Containerfile.ubuntu2204
@@ -59,14 +59,16 @@ RUN /opt/python/$PYTHON_VERSION/bin/pip install --no-cache-dir --upgrade --break
 RUN RUN_UNATTENDED=1 R_VERSION=$R_VERSION bash -c "$(curl -fsSL https://rstd.io/r-install)" && \
     find . -type f -name '[rR]-$R_VERSION.*\.(deb|rpm)' -delete
 
-### Install Quarto and TinyTeX ###
+### Install Quarto ###
+RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
+    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v$QUARTO_VERSION/quarto-$QUARTO_VERSION-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/$QUARTO_VERSION" --strip-components=1 && \
+    ln -s /opt/quarto/$QUARTO_VERSION/bin/quarto /usr/local/bin/quarto
+
+### Install TinyTeX ###
 # Caches won't invalidate correctly on new releases for TinyTeX installs. This ADD instruction is a workaround to bust
 # the cache on new releases.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
-    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v$QUARTO_VERSION/quarto-$QUARTO_VERSION-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/$QUARTO_VERSION" --strip-components=1 && \
-    /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
-    ln -s /opt/quarto/$QUARTO_VERSION/bin/quarto /usr/local/bin/quarto && \
+RUN /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 COPY workbench-session/matrix/conf/vscode.extensions.conf /etc/rstudio/vscode.extensions.conf

--- a/workbench-session/matrix/Containerfile.ubuntu2404
+++ b/workbench-session/matrix/Containerfile.ubuntu2404
@@ -71,14 +71,16 @@ RUN /opt/python/$PYTHON_VERSION/bin/pip install --no-cache-dir --upgrade --break
 RUN RUN_UNATTENDED=1 R_VERSION=$R_VERSION bash -c "$(curl -fsSL https://rstd.io/r-install)" && \
     find . -type f -name '[rR]-$R_VERSION.*\.(deb|rpm)' -delete
 
-### Install Quarto and TinyTeX ###
+### Install Quarto ###
+RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
+    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v$QUARTO_VERSION/quarto-$QUARTO_VERSION-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/$QUARTO_VERSION" --strip-components=1 && \
+    ln -s /opt/quarto/$QUARTO_VERSION/bin/quarto /usr/local/bin/quarto
+
+### Install TinyTeX ###
 # Caches won't invalidate correctly on new releases for TinyTeX installs. This ADD instruction is a workaround to bust
 # the cache on new releases.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
-    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v$QUARTO_VERSION/quarto-$QUARTO_VERSION-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/$QUARTO_VERSION" --strip-components=1 && \
-    /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
-    ln -s /opt/quarto/$QUARTO_VERSION/bin/quarto /usr/local/bin/quarto && \
+RUN /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 COPY workbench-session/matrix/conf/vscode.extensions.conf /etc/rstudio/vscode.extensions.conf

--- a/workbench-session/template/Containerfile.ubuntu2204.jinja2
+++ b/workbench-session/template/Containerfile.ubuntu2204.jinja2
@@ -43,12 +43,15 @@ RUN {{ python.install_packages(python.build_arg(), "ipykernel") }} && \
 # Install R
 {{ r.run_install(r.build_arg()) }}
 
-### Install Quarto and TinyTeX ###
+### Install Quarto ###
+RUN {{ quarto.install(quarto.build_arg()) | indent(4) }} && \
+    {{ quarto.symlink_binary(quarto.build_arg(), "quarto", "/usr/local/bin/quarto") | indent(4) }}
+
+### Install TinyTeX ###
 # Caches won't invalidate correctly on new releases for TinyTeX installs. This ADD instruction is a workaround to bust
 # the cache on new releases.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN {{ quarto.install(quarto.build_arg(), True, True) | indent(4) }} && \
-    {{ quarto.symlink_binary(quarto.build_arg(), "quarto", "/usr/local/bin/quarto") | indent(4) }} && \
+RUN {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto.build_arg() | trim) + "/bin/quarto", True) | indent(4) }} && \
     rm -f /tmp/tinytex-release.json
 
 COPY {{ Path.Version }}/conf/vscode.extensions.conf /etc/rstudio/vscode.extensions.conf

--- a/workbench-session/template/Containerfile.ubuntu2404.jinja2
+++ b/workbench-session/template/Containerfile.ubuntu2404.jinja2
@@ -51,12 +51,15 @@ RUN {{ python.install_packages(python.build_arg(), "ipykernel") }} && \
 # Install R
 {{ r.run_install(r.build_arg()) }}
 
-### Install Quarto and TinyTeX ###
+### Install Quarto ###
+RUN {{ quarto.install(quarto.build_arg()) | indent(4) }} && \
+    {{ quarto.symlink_binary(quarto.build_arg(), "quarto", "/usr/local/bin/quarto") | indent(4) }}
+
+### Install TinyTeX ###
 # Caches won't invalidate correctly on new releases for TinyTeX installs. This ADD instruction is a workaround to bust
 # the cache on new releases.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN {{ quarto.install(quarto.build_arg(), True, True) | indent(4) }} && \
-    {{ quarto.symlink_binary(quarto.build_arg(), "quarto", "/usr/local/bin/quarto") | indent(4) }} && \
+RUN {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto.build_arg() | trim) + "/bin/quarto", True) | indent(4) }} && \
     rm -f /tmp/tinytex-release.json
 
 COPY {{ Path.Version }}/conf/vscode.extensions.conf /etc/rstudio/vscode.extensions.conf


### PR DESCRIPTION
## Summary

Split the combined Quarto + TinyTeX RUN step into two separate steps in the workbench-session templates and matrix files. This matches the pattern already used in the workbench and connect templates.

**Before:** One RUN step downloads Quarto, installs TinyTeX, and symlinks — a failure in any part fails the whole step with no visibility into which part broke.

**After:** Quarto install and TinyTeX install are separate RUN steps with an ADD cache-buster before TinyTeX only.

## Test plan

- [x] Session matrix builds pass (R x Python combinations)
- [x] TinyTeX is installed correctly in built images