### PR TITLE
Add fork-safe PR workflow and permissions

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -42,7 +42,7 @@ jobs:
       - dev
 
     steps:
-      - uses: re-actors/alls-green@release/v1
+      - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # v1.2.2
         id: alls-green
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -19,6 +19,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 concurrency:
   # Only cancel in-progress runs for pull_request events, this prevents cancelling workflows against main or tags
   # A pull_request will reuse the same group thus enabling cancelation, all others receive a unique run_id
@@ -35,6 +37,7 @@ jobs:
     if: always()
 
     runs-on: ubuntu-latest
+    permissions: {}
     timeout-minutes: 10
     needs:
       - dev

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -19,7 +19,6 @@ on:
     branches:
       - main
 
-permissions: {}
 
 concurrency:
   # Only cancel in-progress runs for pull_request events, this prevents cancelling workflows against main or tags

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -15,8 +15,6 @@ on:
     # Hourly rebuild of dev images
     - cron: "45 4 * * *" # At 04:45 every day
 
-  pull_request:
-
   push:
     branches:
       - main

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -21,8 +21,6 @@ on:
 
 
 concurrency:
-  # Only cancel in-progress runs for pull_request events, this prevents cancelling workflows against main or tags
-  # A pull_request will reuse the same group thus enabling cancelation, all others receive a unique run_id
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -15,20 +15,20 @@ jobs:
     steps:
 
       - name: GitHub App Token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3.0.0
         id: app-token
         with:
           app-id: ${{ secrets.WORKBENCH_IDE_RELEASE_APP_ID }}
           private-key: ${{ secrets.WORKBENCH_IDE_RELEASE_PEM }}
 
       - name: Add to Platform Carbon Project
-        uses: actions/add-to-project@v1.0.2
+        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e  # v1.0.2
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           project-url: https://github.com/orgs/posit-dev/projects/17
 
       - name: Add Default Labels
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf  # v1.1.3
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           labels: |

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -28,8 +28,8 @@ jobs:
           project-url: https://github.com/orgs/posit-dev/projects/17
 
       - name: Add Default Labels
-        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf  # v1.1.3
-        with:
-          github_token: ${{ steps.app-token.outputs.token }}
-          labels: |
-            docker
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: gh issue edit "$ISSUE_NUMBER" --add-label "docker"

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -4,11 +4,14 @@ on:
     types:
       - opened
 
+permissions: {}
+
 jobs:
   issue:
     # only run in posit-dev/images-workbench.
     if: github.repository == 'posit-dev/images-workbench'
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
 
       - name: GitHub App Token

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,6 @@ name: Pull Request
 on:
   pull_request:
 
-permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,54 @@
+name: Pull Request
+on:
+  pull_request:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: CI
+    if: always()
+    runs-on: ubuntu-latest
+    permissions: {}
+    timeout-minutes: 10
+    needs:
+      - production
+      - development
+      - session
+    steps:
+      - uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}
+
+  production:
+    name: Production
+    permissions:
+      contents: read
+      packages: write
+    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
+    with:
+      dev-versions: "exclude"
+      matrix-versions: "exclude"
+
+  development:
+    name: Development
+    permissions:
+      contents: read
+      packages: write
+    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
+    with:
+      dev-versions: "only"
+      matrix-versions: "exclude"
+
+  session:
+    name: Session
+    permissions:
+      contents: read
+      packages: write
+    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
+    with:
+      matrix-versions: "only"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,6 +18,7 @@ jobs:
       - production
       - development
       - session
+      - zizmor
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # v1.2.2
         with:
@@ -51,3 +52,14 @@ jobs:
     uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
     with:
       matrix-versions: "only"
+
+  zizmor:
+    name: Zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8  # v0.5.2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,7 +28,7 @@ jobs:
     name: Production
     permissions:
       contents: read
-      packages: read
+      packages: write
     uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
     with:
       dev-versions: "exclude"
@@ -38,7 +38,7 @@ jobs:
     name: Development
     permissions:
       contents: read
-      packages: read
+      packages: write
     uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
     with:
       dev-versions: "only"
@@ -48,7 +48,7 @@ jobs:
     name: Session
     permissions:
       contents: read
-      packages: read
+      packages: write
     uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
     with:
       matrix-versions: "only"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
       - development
       - session
     steps:
-      - uses: re-actors/alls-green@release/v1
+      - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,7 +28,7 @@ jobs:
     name: Production
     permissions:
       contents: read
-      packages: write
+      packages: read
     uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
     with:
       dev-versions: "exclude"
@@ -38,7 +38,7 @@ jobs:
     name: Development
     permissions:
       contents: read
-      packages: write
+      packages: read
     uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
     with:
       dev-versions: "only"
@@ -48,7 +48,7 @@ jobs:
     name: Session
     permissions:
       contents: read
-      packages: write
+      packages: read
     uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
     with:
       matrix-versions: "only"
@@ -58,6 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -10,7 +10,6 @@ on:
     branches:
       - main
 
-permissions: {}
 
 concurrency:
   # Only cancel in-progress runs for pull_request events, this prevents cancelling workflows against main or tags

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -6,8 +6,6 @@ on:
     # Weekly rebuild of all images, to pick up any upstream changes.
     - cron: "15 3 * * 0" # At 03:15 on Sunday
 
-  pull_request:
-
   push:
     branches:
       - main

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -34,7 +34,7 @@ jobs:
       - build
 
     steps:
-      - uses: re-actors/alls-green@release/v1
+      - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # v1.2.2
         id: alls-green
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -12,8 +12,6 @@ on:
 
 
 concurrency:
-  # Only cancel in-progress runs for pull_request events, this prevents cancelling workflows against main or tags
-  # A pull_request will reuse the same group thus enabling cancelation, all others receive a unique run_id
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -10,6 +10,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 concurrency:
   # Only cancel in-progress runs for pull_request events, this prevents cancelling workflows against main or tags
   # A pull_request will reuse the same group thus enabling cancelation, all others receive a unique run_id
@@ -26,6 +28,7 @@ jobs:
     if: always()
 
     runs-on: ubuntu-latest
+    permissions: {}
     timeout-minutes: 10
     needs:
       - lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
         required: true
         type: string
 
+permissions: {}
+
 jobs:
   release:
     uses: posit-dev/images-shared/.github/workflows/product-release.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ on:
 
 jobs:
   release:
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
     uses: posit-dev/images-shared/.github/workflows/product-release.yml@main
     with:
       version: ${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   release:
+    if: github.event_name == 'workflow_dispatch'
     timeout-minutes: 10
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
         required: true
         type: string
 
-permissions: {}
 
 jobs:
   release:

--- a/.github/workflows/session.yml
+++ b/.github/workflows/session.yml
@@ -10,7 +10,6 @@ on:
     branches:
       - main
 
-permissions: {}
 
 concurrency:
   # Only cancel in-progress runs for pull_request events, this prevents cancelling workflows against main or tags

--- a/.github/workflows/session.yml
+++ b/.github/workflows/session.yml
@@ -6,8 +6,6 @@ on:
     # Weekly rebuild of all images, to pick up any upstream changes.
     - cron: "15 4 * * 0" # At 04:15 on Sunday
 
-  pull_request:
-
   push:
     branches:
       - main

--- a/.github/workflows/session.yml
+++ b/.github/workflows/session.yml
@@ -27,7 +27,7 @@ jobs:
     needs:
       - build
     steps:
-      - uses: re-actors/alls-green@release/v1
+      - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # v1.2.2
         id: alls-green
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/session.yml
+++ b/.github/workflows/session.yml
@@ -10,6 +10,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 concurrency:
   # Only cancel in-progress runs for pull_request events, this prevents cancelling workflows against main or tags
   # A pull_request will reuse the same group thus enabling cancelation, all others receive a unique run_id
@@ -21,6 +23,7 @@ jobs:
     name: CI
     if: always()
     runs-on: ubuntu-latest
+    permissions: {}
     timeout-minutes: 10
     needs:
       - build

--- a/.github/workflows/session.yml
+++ b/.github/workflows/session.yml
@@ -44,7 +44,7 @@ jobs:
     # Builds all versions of each image in parallel.
     #
     # Run on merges to main, or on weekly scheduled re-builds.
-    if: contains(fromJSON('["push", "pull_request"]'), github.event_name) || github.event.schedule == '15 3 * * 0'
+    if: github.event_name == 'push' || github.event_name == 'schedule'
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/session.yml
+++ b/.github/workflows/session.yml
@@ -12,8 +12,6 @@ on:
 
 
 concurrency:
-  # Only cancel in-progress runs for pull_request events, this prevents cancelling workflows against main or tags
-  # A pull_request will reuse the same group thus enabling cancelation, all others receive a unique run_id
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 

--- a/.github/workflows/session.yml
+++ b/.github/workflows/session.yml
@@ -46,7 +46,7 @@ jobs:
     # Builds all versions of each image in parallel.
     #
     # Run on merges to main, or on weekly scheduled re-builds.
-    if: github.event_name == 'push' || github.event_name == 'schedule'
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
       packages: write

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,9 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # Shared workflows and composite actions from images-shared
+        # are kept at @main intentionally.
+        "posit-dev/images-shared/*": ref-pin
+        "*": hash-pin
+


### PR DESCRIPTION
## Summary

- Add `pr.yml` calling `bakery-build-pr.yml@main` for fork-safe PR builds (production, development, session)
- Remove `pull_request` trigger from existing build workflows (handled by `pr.yml`)
- Fix `session.yml` cron mismatch (`'15 3 * * 0'` condition vs `'15 4 * * 0'` cron)
- Add `permissions: {}` at workflow level + per-job declarations

Part of rstudio/platform-team#435.

## Test plan

- [ ] `pr.yml` runs on this PR
- [ ] Existing build workflows do not trigger on PRs
- [ ] Push-to-main and schedule triggers still work after merge
- [ ] Session builds trigger correctly on the weekly schedule