### PR TITLE
Add dispatch inputs to development workflow

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -1,6 +1,15 @@
 name: Development
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Product version to build (e.g. 2026.01.2+418.pro1)"
+        required: false
+        type: string
+      stream:
+        description: "Dev stream to build (e.g. 'daily')"
+        required: false
+        type: string
 
   schedule:
     # Hourly rebuild of dev images
@@ -59,7 +68,9 @@ jobs:
     with:
       dev-versions: "only"
       matrix-versions: "exclude"
-      # Push images only for merges into main and hourly schduled re-builds.
+      image-version: ${{ inputs.version }}
+      dev-stream: ${{ inputs.stream }}
+      # Push on merges to main, scheduled rebuilds, and dispatches targeting main.
       push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
 
   clean:


### PR DESCRIPTION
## Summary

- Add `version` and `stream` inputs to `workflow_dispatch` on `development.yml`
- Forward `version` as `image-version` and `stream` as `dev-stream` to the shared `bakery-build-native.yml` workflow (images-shared#480)
- Enables upstream product repos to trigger targeted dev builds (narrow to a specific version + stream)

Part of posit-dev/images-shared#302. Requires images-shared#480 on main (merged).