### PR TITLE
Add Workbench preview release stream

### DIFF
--- a/bakery.yaml
+++ b/bakery.yaml
@@ -65,6 +65,22 @@ images:
           - host: "ghcr.io"
             namespace: "posit-dev"
             repository: "workbench-preview"
+      - sourceType: stream
+        product: workbench
+        stream: preview
+        values:
+          channel: "apple-blossom"
+        os:
+          - name: Ubuntu 24.04
+            primary: true
+            platforms:
+              - linux/amd64
+              - linux/arm64
+          - name: Ubuntu 22.04
+        overrideRegistries:
+          - host: "ghcr.io"
+            namespace: "posit-dev"
+            repository: "workbench-preview"
     versions:
       - name: 2026.01.2+418.pro1
         subpath: '2026.01'
@@ -97,6 +113,21 @@ images:
       - sourceType: stream
         product: workbench-session
         stream: daily
+        os:
+          - name: Ubuntu 24.04
+            primary: true
+            platforms:
+              - linux/amd64
+              - linux/arm64
+        overrideRegistries:
+          - host: "ghcr.io"
+            namespace: "posit-dev"
+            repository: "workbench-session-init-preview"
+      - sourceType: stream
+        product: workbench-session
+        stream: preview
+        values:
+          channel: "apple-blossom"
         os:
           - name: Ubuntu 24.04
             primary: true


### PR DESCRIPTION
## Summary

- Add preview `devVersion` entries for both `workbench` and `workbench-session-init`
- Uses the `apple-blossom` branch codename via `values.channel`
- Bakery resolves the branch-specific dailies URL (`https://dailies.rstudio.com/rstudio/apple-blossom/index.json`)
- When the preview branch rolls forward, update `channel` in this file

Stacked on top of #74.