### PR TITLE
Install Quarto from the Posit Open apt repo in workbench-session

### DIFF
--- a/workbench-session-init/2025.09/Containerfile.ubuntu2404
+++ b/workbench-session-init/2025.09/Containerfile.ubuntu2404
@@ -1,6 +1,8 @@
 FROM docker.io/library/ubuntu:24.04 AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG BUILDARCH
+ARG TARGETARCH=${BUILDARCH}
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
@@ -19,8 +21,13 @@ RUN apt-get update -yqq --fix-missing && \
     rm -rf /var/lib/apt/lists/*
 
 # Download the RStudio Workbench session components
-RUN mkdir -p /pwb-staging && \
-    curl -fsSL -o /pwb-staging/rsp-session-multi-linux.tar.gz "https://s3.amazonaws.com/rstudio-ide-build/session/multi/x86_64/rsp-session-multi-linux-2025.09.2-418.pro4-x86_64.tar.gz" && \
+RUN case ${TARGETARCH} in \
+      amd64) CDN_ARCH=x86_64 ;; \
+      arm64) CDN_ARCH=arm64 ;; \
+      *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
+    esac && \
+    mkdir -p /pwb-staging && \
+    curl -fsSL -o /pwb-staging/rsp-session-multi-linux.tar.gz "https://s3.amazonaws.com/rstudio-ide-build/session/multi/$CDN_ARCH/rsp-session-multi-linux-2025.09.2-418.pro4-$CDN_ARCH.tar.gz" && \
     mkdir -p /opt/session-components && \
     tar -C /opt/session-components -xpf /pwb-staging/rsp-session-multi-linux.tar.gz && \
     chmod 755 /opt/session-components && \

--- a/workbench-session-init/2026.01/Containerfile.ubuntu2404
+++ b/workbench-session-init/2026.01/Containerfile.ubuntu2404
@@ -1,6 +1,8 @@
 FROM docker.io/library/ubuntu:24.04 AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG BUILDARCH
+ARG TARGETARCH=${BUILDARCH}
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
@@ -19,8 +21,13 @@ RUN apt-get update -yqq --fix-missing && \
     rm -rf /var/lib/apt/lists/*
 
 # Download the RStudio Workbench session components
-RUN mkdir -p /pwb-staging && \
-    curl -fsSL -o /pwb-staging/rsp-session-multi-linux.tar.gz "https://s3.amazonaws.com/rstudio-ide-build/session/multi/x86_64/rsp-session-multi-linux-2026.01.2-418.pro1-x86_64.tar.gz" && \
+RUN case ${TARGETARCH} in \
+      amd64) CDN_ARCH=x86_64 ;; \
+      arm64) CDN_ARCH=arm64 ;; \
+      *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
+    esac && \
+    mkdir -p /pwb-staging && \
+    curl -fsSL -o /pwb-staging/rsp-session-multi-linux.tar.gz "https://s3.amazonaws.com/rstudio-ide-build/session/multi/$CDN_ARCH/rsp-session-multi-linux-2026.01.2-418.pro1-$CDN_ARCH.tar.gz" && \
     mkdir -p /opt/session-components && \
     tar -C /opt/session-components -xpf /pwb-staging/rsp-session-multi-linux.tar.gz && \
     chmod 755 /opt/session-components && \

--- a/workbench-session/matrix/Containerfile.ubuntu2204
+++ b/workbench-session/matrix/Containerfile.ubuntu2204
@@ -21,8 +21,6 @@ ARG R_VERSION
 ARG PYTHON_VERSION
 ARG QUARTO_VERSION
 
-SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
-
 ### Install Apt Packages ###
 RUN apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
@@ -68,16 +66,23 @@ RUN RUN_UNATTENDED=1 R_VERSION=$R_VERSION bash -c "$(curl -fsSL https://rstd.io/
     find . -type f -name '[rR]-$R_VERSION.*\.(deb|rpm)' -delete
 
 ### Install Quarto ###
-RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
-    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v$QUARTO_VERSION/quarto-$QUARTO_VERSION-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/$QUARTO_VERSION" --strip-components=1 && \
-    ln -s /opt/quarto/$QUARTO_VERSION/bin/quarto /usr/local/bin/quarto
+RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
+    apt-get install -yqq --no-install-recommends \
+        quarto=$QUARTO_VERSION && \
+    apt-mark hold quarto && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
 
 ### Install TinyTeX ###
-# Caches won't invalidate correctly on new releases for TinyTeX installs. This ADD instruction is a workaround to bust
-# the cache on new releases.
+# ADD busts the cache on new TinyTeX releases.
+# HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        xz-utils && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/* && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 COPY workbench-session/matrix/conf/vscode.extensions.conf /etc/rstudio/vscode.extensions.conf

--- a/workbench-session/matrix/Containerfile.ubuntu2404
+++ b/workbench-session/matrix/Containerfile.ubuntu2404
@@ -21,8 +21,6 @@ ARG R_VERSION
 ARG PYTHON_VERSION
 ARG QUARTO_VERSION
 
-SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
-
 ### Install Apt Packages ###
 RUN apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
@@ -76,16 +74,23 @@ RUN RUN_UNATTENDED=1 R_VERSION=$R_VERSION bash -c "$(curl -fsSL https://rstd.io/
     find . -type f -name '[rR]-$R_VERSION.*\.(deb|rpm)' -delete
 
 ### Install Quarto ###
-RUN mkdir -p /opt/quarto/$QUARTO_VERSION && \
-    curl -fsSL "https://github.com/quarto-dev/quarto-cli/releases/download/v$QUARTO_VERSION/quarto-$QUARTO_VERSION-linux-${TARGETARCH}.tar.gz" | tar xzf - -C "/opt/quarto/$QUARTO_VERSION" --strip-components=1 && \
-    ln -s /opt/quarto/$QUARTO_VERSION/bin/quarto /usr/local/bin/quarto
+RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
+    apt-get install -yqq --no-install-recommends \
+        quarto=$QUARTO_VERSION && \
+    apt-mark hold quarto && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
 
 ### Install TinyTeX ###
-# Caches won't invalidate correctly on new releases for TinyTeX installs. This ADD instruction is a workaround to bust
-# the cache on new releases.
+# ADD busts the cache on new TinyTeX releases.
+# HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/$QUARTO_VERSION/bin/quarto install tinytex --no-prompt --quiet --update-path && \
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        xz-utils && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/* && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 
 COPY workbench-session/matrix/conf/vscode.extensions.conf /etc/rstudio/vscode.extensions.conf

--- a/workbench-session/matrix/test/goss.yaml
+++ b/workbench-session/matrix/test/goss.yaml
@@ -5,6 +5,10 @@ package:
   {{.}}:
     installed: true
   {{end}}
+  quarto:
+    installed: true
+    versions:
+      - {{ .Env.BUILD_ARG_QUARTO_VERSION }}
 
 file:
   python-{{ .Env.BUILD_ARG_PYTHON_VERSION }}:
@@ -13,9 +17,19 @@ file:
   r-{{ .Env.BUILD_ARG_R_VERSION }}:
     exists: true
     path: /opt/R/{{ .Env.BUILD_ARG_R_VERSION }}
-  quarto-{{ .Env.BUILD_ARG_QUARTO_VERSION }}:
+  quarto:
     exists: true
-    path: /opt/quarto/{{ .Env.BUILD_ARG_QUARTO_VERSION }}
+    path: /opt/quarto/bin/quarto
+  # TinyTeX is installed under /opt/.TinyTeX; tlmgr path add symlinks binaries into /usr/local/bin.
+  /opt/.TinyTeX:
+    exists: true
+    filetype: directory
+  /usr/local/bin/tlmgr:
+    exists: true
+    filetype: symlink
+  /usr/local/bin/pdflatex:
+    exists: true
+    filetype: symlink
 
 command:
   "Verify Jupyter Notebook works":
@@ -44,4 +58,18 @@ command:
     exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date/"
+      # "External Installation" because Quarto doesn't recognize TinyTeX installed under HOME="/opt".
+      # TODO: Switch to "Up to date" once https://github.com/quarto-dev/quarto-cli/issues/11800 lands.
+      - "/tinytex\\s+External Installation/"
+  "Verify TinyTeX is readable and executable by a non-root user":
+    exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' nobody
+    exit-status: 0
+    stdout:
+      - "tlmgr"
+      - "pdfTeX"
+  "Verify quarto package is held":
+    # Guards against apt upgrade drifting quarto off the pinned version.
+    exec: apt-mark showhold
+    exit-status: 0
+    stdout:
+      - "/^quarto$/"

--- a/workbench-session/template/Containerfile.ubuntu2204.jinja2
+++ b/workbench-session/template/Containerfile.ubuntu2204.jinja2
@@ -21,8 +21,6 @@ ARG TARGETARCH=${BUILDARCH}
 {{ python.declare_build_arg() }}
 {{ quarto.declare_build_arg() }}
 
-SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
-
 ### Install Apt Packages ###
 {{ apt.run_setup() }}
 
@@ -43,15 +41,14 @@ RUN {{ python.install_packages(python.build_arg(), "ipykernel") }} && \
 {{ r.run_install(r.build_arg()) }}
 
 ### Install Quarto ###
-RUN {{ quarto.install(quarto.build_arg()) | indent(4) }} && \
-    {{ quarto.symlink_binary(quarto.build_arg(), "quarto", "/usr/local/bin/quarto") | indent(4) }}
+RUN {{ quarto.install(quarto.build_arg()) | indent(4) }}
 
 ### Install TinyTeX ###
-# Caches won't invalidate correctly on new releases for TinyTeX installs. This ADD instruction is a workaround to bust
-# the cache on new releases.
+# ADD busts the cache on new TinyTeX releases.
+# HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN {{ quarto.github_token_secret_mount() }} \
-    {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto.build_arg() | trim) + "/bin/quarto", True, home_path="/opt") | indent(4) }} && \
+RUN {{ apt.install(packages="xz-utils") | indent(4) }} && \
+    {{ quarto.install_tinytex_command(quarto.get_directory() ~ "/bin/quarto", update_path=True, home_path="/opt") | indent(4) }} && \
     rm -f /tmp/tinytex-release.json
 
 COPY {{ Path.Version }}/conf/vscode.extensions.conf /etc/rstudio/vscode.extensions.conf

--- a/workbench-session/template/Containerfile.ubuntu2404.jinja2
+++ b/workbench-session/template/Containerfile.ubuntu2404.jinja2
@@ -21,8 +21,6 @@ ARG TARGETARCH=${BUILDARCH}
 {{ python.declare_build_arg() }}
 {{ quarto.declare_build_arg() }}
 
-SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
-
 ### Install Apt Packages ###
 {{ apt.run_setup() }}
 
@@ -47,15 +45,14 @@ RUN {{ python.install_packages(python.build_arg(), "ipykernel") }} && \
 {{ r.run_install(r.build_arg()) }}
 
 ### Install Quarto ###
-RUN {{ quarto.install(quarto.build_arg()) | indent(4) }} && \
-    {{ quarto.symlink_binary(quarto.build_arg(), "quarto", "/usr/local/bin/quarto") | indent(4) }}
+RUN {{ quarto.install(quarto.build_arg()) | indent(4) }}
 
 ### Install TinyTeX ###
-# Caches won't invalidate correctly on new releases for TinyTeX installs. This ADD instruction is a workaround to bust
-# the cache on new releases.
+# ADD busts the cache on new TinyTeX releases.
+# HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN {{ quarto.github_token_secret_mount() }} \
-    {{ quarto.install_tinytex_command(quarto.get_version_directory(quarto.build_arg() | trim) + "/bin/quarto", True, home_path="/opt") | indent(4) }} && \
+RUN {{ apt.install(packages="xz-utils") | indent(4) }} && \
+    {{ quarto.install_tinytex_command(quarto.get_directory() ~ "/bin/quarto", update_path=True, home_path="/opt") | indent(4) }} && \
     rm -f /tmp/tinytex-release.json
 
 COPY {{ Path.Version }}/conf/vscode.extensions.conf /etc/rstudio/vscode.extensions.conf

--- a/workbench-session/template/test/goss.yaml.jinja2
+++ b/workbench-session/template/test/goss.yaml.jinja2
@@ -12,6 +12,10 @@ package:
     installed: true
   {{end}}
   {%- endraw %}
+  quarto:
+    installed: true
+    versions:
+      - {{ goss.build_arg_env_var("QUARTO_VERSION") }}
 
 file:
   python-{{ goss.build_arg_env_var("PYTHON_VERSION") }}:
@@ -20,9 +24,19 @@ file:
   r-{{ goss.build_arg_env_var("R_VERSION") }}:
     exists: true
     path: {{ r.get_version_directory(goss.build_arg_env_var("R_VERSION")) }}
-  quarto-{{ goss.build_arg_env_var("QUARTO_VERSION") }}:
+  quarto:
     exists: true
-    path: {{ quarto.get_version_directory(goss.build_arg_env_var("QUARTO_VERSION")) }}
+    path: {{ quarto.get_directory() }}/bin/quarto
+  # TinyTeX is installed under /opt/.TinyTeX; tlmgr path add symlinks binaries into /usr/local/bin.
+  /opt/.TinyTeX:
+    exists: true
+    filetype: directory
+  /usr/local/bin/tlmgr:
+    exists: true
+    filetype: symlink
+  /usr/local/bin/pdflatex:
+    exists: true
+    filetype: symlink
 
 command:
   "Verify Jupyter Notebook works":
@@ -51,4 +65,18 @@ command:
     exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date/"
+      # "External Installation" because Quarto doesn't recognize TinyTeX installed under HOME="/opt".
+      # TODO: Switch to "Up to date" once https://github.com/quarto-dev/quarto-cli/issues/11800 lands.
+      - "/tinytex\\s+External Installation/"
+  "Verify TinyTeX is readable and executable by a non-root user":
+    exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' nobody
+    exit-status: 0
+    stdout:
+      - "tlmgr"
+      - "pdfTeX"
+  "Verify quarto package is held":
+    # Guards against apt upgrade drifting quarto off the pinned version.
+    exec: apt-mark showhold
+    exit-status: 0
+    stdout:
+      - "/^quarto$/"

--- a/workbench/2025.09/Containerfile.ubuntu2204.std
+++ b/workbench/2025.09/Containerfile.ubuntu2204.std
@@ -30,8 +30,6 @@ ENV DIAGNOSTIC_DIR=/var/log/rstudio
 ENV DIAGNOSTIC_ENABLE=false
 ENV DIAGNOSTIC_ONLY=false
 
-SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
-
 ### Setup environment ###
 RUN apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
@@ -95,7 +93,7 @@ RUN /opt/python/3.13.7/bin/pip install --no-cache-dir --upgrade --break-system-p
 ### Install Pro Drivers ###
 RUN apt-get install -yq rstudio-drivers && \
     apt-get clean -yqq && \
-    rm -rf /var/lib/apt/lists/*
+rm -rf /var/lib/apt/lists/*
 
 ### Copy startup scripts ###
 COPY --chmod=0775 "workbench/2025.09/scripts/startup.sh" /usr/local/bin/startup.sh
@@ -104,7 +102,7 @@ COPY "workbench/2025.09/startup/base" /startup/base
 COPY "workbench/2025.09/startup/supervisord.conf" /etc/supervisor/supervisord.conf
 COPY "workbench/2025.09/startup/user-provisioning" /startup/user-provisioning
 COPY --chmod=600 "workbench/2025.09/conf/sssd/sssd.conf" /etc/sssd/sssd.conf
-COPY "workbench/2025.09/conf/jupyter/*" "workbench/2025.09/conf/launcher/*" "workbench/2025.09/conf/rstudio/*" "workbench/2025.09/conf/positron/*" "workbench/2025.09/conf/vscode/*" /etc/rstudio/
+COPY "workbench/2025.09/conf/jupyter/*" "workbench/2025.09/conf/launcher/*" "workbench/2025.09/conf/rstudio/*" "workbench/2025.09/conf/positron/*" "workbench/2025.09/conf/vscode/*" /etc/rstudio
 
 ### Configure Workbench ###
 RUN mkdir -p /var/lib/rstudio-server/monitor/log \
@@ -118,9 +116,14 @@ RUN mkdir -p /var/lib/rstudio-server/monitor/log \
 ### Install TinyTeX using Quarto ###
 # Caches won't invalidate correctly on new releases for TinyTeX installs. This ADD instruction is a workaround to bust
 # the cache on new releases.
+#
+# TinyTeX is installed under HOME="/opt" so the install lands at /opt/.TinyTeX,
+# which is readable by non-root runtime users. `--update-path` makes tlmgr
+# symlink the TinyTeX binaries into /usr/local/bin.
+# TODO: Remove `HOME="/opt"` once Quarto supports custom install locations
+# for TinyTeX, see https://github.com/quarto-dev/quarto-cli/issues/11800.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path \
+RUN HOME="/opt" /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path \
     && rm -f /tmp/tinytex-release.json
 
 EXPOSE 8787/tcp

--- a/workbench/2025.09/Containerfile.ubuntu2404.std
+++ b/workbench/2025.09/Containerfile.ubuntu2404.std
@@ -30,8 +30,6 @@ ENV DIAGNOSTIC_DIR=/var/log/rstudio
 ENV DIAGNOSTIC_ENABLE=false
 ENV DIAGNOSTIC_ONLY=false
 
-SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
-
 ### Setup environment ###
 RUN apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
@@ -57,7 +55,8 @@ RUN apt-get update -yqq && \
 
 
 ### Install wait-for-it ###
-COPY --chmod=0755 workbench/scripts/wait-for-it.sh /usr/local/bin/wait-for-it.sh
+RUN curl -fsSL -o /usr/local/bin/wait-for-it.sh https://raw.githubusercontent.com/rstudio/wait-for-it/master/wait-for-it.sh && \
+    chmod +x /usr/local/bin/wait-for-it.sh
 
 ### Install Workbench 2025.09.2+418.pro4 ###
 COPY --chmod=0755 workbench/2025.09/scripts/install_workbench.sh /tmp/install_workbench.sh
@@ -78,13 +77,7 @@ COPY --from=python-builder /opt/python /opt/python
 ### Install Jupyter ###
 RUN /opt/python/3.13.7/bin/python -m venv /opt/python/jupyter && \
     /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade \
-        "jupyterlab<5" \
-        notebook \
-        "pwb_jupyterlab<2" && \
-    rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests && \
-    rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/galata && \
-    rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \
+    /opt/python/jupyter/bin/pip install --no-cache-dir 'jupyterlab<5' notebook 'pwb_jupyterlab<2' && \
     ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
 
 ### Install Jupyter kernels ###
@@ -93,12 +86,9 @@ RUN /opt/python/3.13.7/bin/pip install --no-cache-dir --upgrade --break-system-p
     /opt/python/3.13.7/bin/python -m ipykernel install --user --name python3.13.7 --display-name "Python 3.13.7"
 
 ### Install Pro Drivers ###
-RUN apt-get update -yqq && \
-    apt-get install -yqq --no-install-recommends \
-        rstudio-drivers && \
+RUN apt-get install -yq rstudio-drivers && \
     apt-get clean -yqq && \
-    rm -rf /var/lib/apt/lists/*
-RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
+rm -rf /var/lib/apt/lists/*
 
 ### Copy startup scripts ###
 COPY --chmod=0775 "workbench/2025.09/scripts/startup.sh" /usr/local/bin/startup.sh
@@ -107,7 +97,7 @@ COPY "workbench/2025.09/startup/base" /startup/base
 COPY "workbench/2025.09/startup/supervisord.conf" /etc/supervisor/supervisord.conf
 COPY "workbench/2025.09/startup/user-provisioning" /startup/user-provisioning
 COPY --chmod=600 "workbench/2025.09/conf/sssd/sssd.conf" /etc/sssd/sssd.conf
-COPY "workbench/2025.09/conf/jupyter/*" "workbench/2025.09/conf/launcher/*" "workbench/2025.09/conf/rstudio/*" "workbench/2025.09/conf/positron/*" "workbench/2025.09/conf/vscode/*" /etc/rstudio/
+COPY "workbench/2025.09/conf/jupyter/*" "workbench/2025.09/conf/launcher/*" "workbench/2025.09/conf/rstudio/*" "workbench/2025.09/conf/positron/*" "workbench/2025.09/conf/vscode/*" /etc/rstudio
 
 ### Configure Workbench ###
 RUN mkdir -p /var/lib/rstudio-server/monitor/log \
@@ -121,9 +111,14 @@ RUN mkdir -p /var/lib/rstudio-server/monitor/log \
 ### Install TinyTeX using Quarto ###
 # Caches won't invalidate correctly on new releases for TinyTeX installs. This ADD instruction is a workaround to bust
 # the cache on new releases.
+#
+# TinyTeX is installed under HOME="/opt" so the install lands at /opt/.TinyTeX,
+# which is readable by non-root runtime users. `--update-path` makes tlmgr
+# symlink the TinyTeX binaries into /usr/local/bin.
+# TODO: Remove `HOME="/opt"` once Quarto supports custom install locations
+# for TinyTeX, see https://github.com/quarto-dev/quarto-cli/issues/11800.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path \
+RUN HOME="/opt" /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path \
     && rm -f /tmp/tinytex-release.json
 
 EXPOSE 8787/tcp

--- a/workbench/2025.09/test/goss.yaml
+++ b/workbench/2025.09/test/goss.yaml
@@ -114,6 +114,18 @@ file:
   /usr/local/bin/quarto:
     exists: true
     filetype: symlink
+  # TinyTeX is installed under /opt/.TinyTeX (via HOME="/opt") so non-root runtime
+  # users can read the install; tlmgr path add symlinks the binaries into
+  # /usr/local/bin so they are on PATH.
+  /opt/.TinyTeX:
+    exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
+    filetype: directory
+  /usr/local/bin/tlmgr:
+    exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
+    filetype: symlink
+  /usr/local/bin/pdflatex:
+    exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
+    filetype: symlink
   # Check for R installation
 
   /opt/R/4.5.1/bin/R:
@@ -210,5 +222,21 @@ command:
     exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date/"
+      # "External Installation" is reported because TinyTeX is installed under
+      # HOME="/opt" so Quarto does not consider it one of its managed installs.
+      # TODO: Switch back to "Up to date" once Quarto supports a custom TinyTeX
+      # install location, see https://github.com/quarto-dev/quarto-cli/issues/11800.
+      - "/tinytex\\s+External Installation/"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Verify TinyTeX is readable and executable by a non-root user":
+    # Runs tlmgr and pdflatex as `nobody` to confirm the /opt/.TinyTeX install
+    # is accessible to non-root. `command -v` also forces PATH resolution,
+    # not just direct invocation — proves the /usr/local/bin symlinks are on
+    # the user's PATH. Guards against regressions in placement, permissions,
+    # or PATH setup.
+    exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' nobody
+    exit-status: 0
+    stdout:
+      - "tlmgr"
+      - "pdfTeX"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}

--- a/workbench/2026.01/Containerfile.ubuntu2204.std
+++ b/workbench/2026.01/Containerfile.ubuntu2204.std
@@ -30,8 +30,6 @@ ENV DIAGNOSTIC_DIR=/var/log/rstudio
 ENV DIAGNOSTIC_ENABLE=false
 ENV DIAGNOSTIC_ONLY=false
 
-SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
-
 ### Setup environment ###
 RUN apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
@@ -95,7 +93,7 @@ RUN /opt/python/3.14.2/bin/pip install --no-cache-dir --upgrade --break-system-p
 ### Install Pro Drivers ###
 RUN apt-get install -yq rstudio-drivers && \
     apt-get clean -yqq && \
-    rm -rf /var/lib/apt/lists/*
+rm -rf /var/lib/apt/lists/*
 
 ### Copy startup scripts ###
 COPY --chmod=0775 "workbench/2026.01/scripts/startup.sh" /usr/local/bin/startup.sh
@@ -104,7 +102,7 @@ COPY "workbench/2026.01/startup/base" /startup/base
 COPY "workbench/2026.01/startup/supervisord.conf" /etc/supervisor/supervisord.conf
 COPY "workbench/2026.01/startup/user-provisioning" /startup/user-provisioning
 COPY --chmod=600 "workbench/2026.01/conf/sssd/sssd.conf" /etc/sssd/sssd.conf
-COPY "workbench/2026.01/conf/jupyter/*" "workbench/2026.01/conf/launcher/*" "workbench/2026.01/conf/rstudio/*" "workbench/2026.01/conf/positron/*" "workbench/2026.01/conf/vscode/*" /etc/rstudio/
+COPY "workbench/2026.01/conf/jupyter/*" "workbench/2026.01/conf/launcher/*" "workbench/2026.01/conf/rstudio/*" "workbench/2026.01/conf/positron/*" "workbench/2026.01/conf/vscode/*" /etc/rstudio
 
 ### Configure Workbench ###
 RUN mkdir -p /var/lib/rstudio-server/monitor/log \
@@ -118,9 +116,14 @@ RUN mkdir -p /var/lib/rstudio-server/monitor/log \
 ### Install TinyTeX using Quarto ###
 # Caches won't invalidate correctly on new releases for TinyTeX installs. This ADD instruction is a workaround to bust
 # the cache on new releases.
+#
+# TinyTeX is installed under HOME="/opt" so the install lands at /opt/.TinyTeX,
+# which is readable by non-root runtime users. `--update-path` makes tlmgr
+# symlink the TinyTeX binaries into /usr/local/bin.
+# TODO: Remove `HOME="/opt"` once Quarto supports custom install locations
+# for TinyTeX, see https://github.com/quarto-dev/quarto-cli/issues/11800.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path \
+RUN HOME="/opt" /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path \
     && rm -f /tmp/tinytex-release.json
 
 EXPOSE 8787/tcp

--- a/workbench/2026.01/Containerfile.ubuntu2404.std
+++ b/workbench/2026.01/Containerfile.ubuntu2404.std
@@ -30,8 +30,6 @@ ENV DIAGNOSTIC_DIR=/var/log/rstudio
 ENV DIAGNOSTIC_ENABLE=false
 ENV DIAGNOSTIC_ONLY=false
 
-SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
-
 ### Setup environment ###
 RUN apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
@@ -93,12 +91,9 @@ RUN /opt/python/3.14.2/bin/pip install --no-cache-dir --upgrade --break-system-p
     /opt/python/3.14.2/bin/python -m ipykernel install --user --name python3.14.2 --display-name "Python 3.14.2"
 
 ### Install Pro Drivers ###
-RUN apt-get update -yqq && \
-    apt-get install -yqq --no-install-recommends \
-        rstudio-drivers && \
+RUN apt-get install -yq rstudio-drivers && \
     apt-get clean -yqq && \
-    rm -rf /var/lib/apt/lists/*
-RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
+rm -rf /var/lib/apt/lists/*
 
 ### Copy startup scripts ###
 COPY --chmod=0775 "workbench/2026.01/scripts/startup.sh" /usr/local/bin/startup.sh
@@ -107,7 +102,7 @@ COPY "workbench/2026.01/startup/base" /startup/base
 COPY "workbench/2026.01/startup/supervisord.conf" /etc/supervisor/supervisord.conf
 COPY "workbench/2026.01/startup/user-provisioning" /startup/user-provisioning
 COPY --chmod=600 "workbench/2026.01/conf/sssd/sssd.conf" /etc/sssd/sssd.conf
-COPY "workbench/2026.01/conf/jupyter/*" "workbench/2026.01/conf/launcher/*" "workbench/2026.01/conf/rstudio/*" "workbench/2026.01/conf/positron/*" "workbench/2026.01/conf/vscode/*" /etc/rstudio/
+COPY "workbench/2026.01/conf/jupyter/*" "workbench/2026.01/conf/launcher/*" "workbench/2026.01/conf/rstudio/*" "workbench/2026.01/conf/positron/*" "workbench/2026.01/conf/vscode/*" /etc/rstudio
 
 ### Configure Workbench ###
 RUN mkdir -p /var/lib/rstudio-server/monitor/log \
@@ -121,9 +116,14 @@ RUN mkdir -p /var/lib/rstudio-server/monitor/log \
 ### Install TinyTeX using Quarto ###
 # Caches won't invalidate correctly on new releases for TinyTeX installs. This ADD instruction is a workaround to bust
 # the cache on new releases.
+#
+# TinyTeX is installed under HOME="/opt" so the install lands at /opt/.TinyTeX,
+# which is readable by non-root runtime users. `--update-path` makes tlmgr
+# symlink the TinyTeX binaries into /usr/local/bin.
+# TODO: Remove `HOME="/opt"` once Quarto supports custom install locations
+# for TinyTeX, see https://github.com/quarto-dev/quarto-cli/issues/11800.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path \
+RUN HOME="/opt" /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path \
     && rm -f /tmp/tinytex-release.json
 
 EXPOSE 8787/tcp

--- a/workbench/2026.01/test/goss.yaml
+++ b/workbench/2026.01/test/goss.yaml
@@ -114,6 +114,18 @@ file:
   /usr/local/bin/quarto:
     exists: true
     filetype: symlink
+  # TinyTeX is installed under /opt/.TinyTeX (via HOME="/opt") so non-root runtime
+  # users can read the install; tlmgr path add symlinks the binaries into
+  # /usr/local/bin so they are on PATH.
+  /opt/.TinyTeX:
+    exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
+    filetype: directory
+  /usr/local/bin/tlmgr:
+    exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
+    filetype: symlink
+  /usr/local/bin/pdflatex:
+    exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
+    filetype: symlink
   # Check for R installation
 
   /opt/R/4.5.2/bin/R:
@@ -210,5 +222,21 @@ command:
     exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date/"
+      # "External Installation" is reported because TinyTeX is installed under
+      # HOME="/opt" so Quarto does not consider it one of its managed installs.
+      # TODO: Switch back to "Up to date" once Quarto supports a custom TinyTeX
+      # install location, see https://github.com/quarto-dev/quarto-cli/issues/11800.
+      - "/tinytex\\s+External Installation/"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Verify TinyTeX is readable and executable by a non-root user":
+    # Runs tlmgr and pdflatex as `nobody` to confirm the /opt/.TinyTeX install
+    # is accessible to non-root. `command -v` also forces PATH resolution,
+    # not just direct invocation — proves the /usr/local/bin symlinks are on
+    # the user's PATH. Guards against regressions in placement, permissions,
+    # or PATH setup.
+    exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' nobody
+    exit-status: 0
+    stdout:
+      - "tlmgr"
+      - "pdfTeX"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}

--- a/workbench/template/Containerfile.ubuntu2204.jinja2
+++ b/workbench/template/Containerfile.ubuntu2204.jinja2
@@ -34,8 +34,6 @@ ENV DIAGNOSTIC_DIR=/var/log/rstudio
 ENV DIAGNOSTIC_ENABLE=false
 ENV DIAGNOSTIC_ONLY=false
 
-SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
-
 ### Setup environment ###
 {{ apt.run_setup() }}
 
@@ -80,7 +78,7 @@ RUN {{ python.install_packages(python_version, "ipykernel") }} && \
 
 ### Install Pro Drivers ###
 RUN apt-get install -yq rstudio-drivers && \
-    {{ apt.clean_command() | indent(4) }}
+    {{ apt.clean_command() }}
 {%- endif %}
 
 ### Copy startup scripts ###
@@ -92,7 +90,7 @@ COPY "{{ Path.Version }}/startup/supervisord.conf" /etc/supervisor/supervisord.c
 COPY "{{ Path.Version }}/startup/user-provisioning" /startup/user-provisioning
 COPY --chmod=600 "{{ Path.Version }}/conf/sssd/sssd.conf" /etc/sssd/sssd.conf
 {%- endif %}
-COPY "{{ Path.Version }}/conf/jupyter/*" "{{ Path.Version }}/conf/launcher/*" "{{ Path.Version }}/conf/rstudio/*" "{{ Path.Version }}/conf/positron/*" "{{ Path.Version }}/conf/vscode/*" /etc/rstudio/
+COPY "{{ Path.Version }}/conf/jupyter/*" "{{ Path.Version }}/conf/launcher/*" "{{ Path.Version }}/conf/rstudio/*" "{{ Path.Version }}/conf/positron/*" "{{ Path.Version }}/conf/vscode/*" /etc/rstudio
 
 ### Configure Workbench ###
 RUN mkdir -p /var/lib/rstudio-server/monitor/log \
@@ -108,9 +106,14 @@ RUN mkdir -p /var/lib/rstudio-server/monitor/log \
 ### Install TinyTeX using Quarto ###
 # Caches won't invalidate correctly on new releases for TinyTeX installs. This ADD instruction is a workaround to bust
 # the cache on new releases.
+#
+# TinyTeX is installed under HOME="/opt" so the install lands at /opt/.TinyTeX,
+# which is readable by non-root runtime users. `--update-path` makes tlmgr
+# symlink the TinyTeX binaries into /usr/local/bin.
+# TODO: Remove `HOME="/opt"` once Quarto supports custom install locations
+# for TinyTeX, see https://github.com/quarto-dev/quarto-cli/issues/11800.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN {{ quarto.github_token_secret_mount() }} \
-    {{ quarto.install_tinytex_command("/lib/rstudio-server/bin/quarto/bin/quarto", True, home_path="/opt") }} \
+RUN {{ quarto.install_tinytex_command("/lib/rstudio-server/bin/quarto/bin/quarto", update_path=True, home_path="/opt") }} \
     && rm -f /tmp/tinytex-release.json
 {%- endif %}
 

--- a/workbench/template/Containerfile.ubuntu2404.jinja2
+++ b/workbench/template/Containerfile.ubuntu2404.jinja2
@@ -34,8 +34,6 @@ ENV DIAGNOSTIC_DIR=/var/log/rstudio
 ENV DIAGNOSTIC_ENABLE=false
 ENV DIAGNOSTIC_ONLY=false
 
-SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
-
 ### Setup environment ###
 {{ apt.run_setup() }}
 
@@ -92,7 +90,7 @@ COPY "{{ Path.Version }}/startup/supervisord.conf" /etc/supervisor/supervisord.c
 COPY "{{ Path.Version }}/startup/user-provisioning" /startup/user-provisioning
 COPY --chmod=600 "{{ Path.Version }}/conf/sssd/sssd.conf" /etc/sssd/sssd.conf
 {%- endif %}
-COPY "{{ Path.Version }}/conf/jupyter/*" "{{ Path.Version }}/conf/launcher/*" "{{ Path.Version }}/conf/rstudio/*" "{{ Path.Version }}/conf/positron/*" "{{ Path.Version }}/conf/vscode/*" /etc/rstudio/
+COPY "{{ Path.Version }}/conf/jupyter/*" "{{ Path.Version }}/conf/launcher/*" "{{ Path.Version }}/conf/rstudio/*" "{{ Path.Version }}/conf/positron/*" "{{ Path.Version }}/conf/vscode/*" /etc/rstudio
 
 ### Configure Workbench ###
 RUN mkdir -p /var/lib/rstudio-server/monitor/log \
@@ -108,9 +106,14 @@ RUN mkdir -p /var/lib/rstudio-server/monitor/log \
 ### Install TinyTeX using Quarto ###
 # Caches won't invalidate correctly on new releases for TinyTeX installs. This ADD instruction is a workaround to bust
 # the cache on new releases.
+#
+# TinyTeX is installed under HOME="/opt" so the install lands at /opt/.TinyTeX,
+# which is readable by non-root runtime users. `--update-path` makes tlmgr
+# symlink the TinyTeX binaries into /usr/local/bin.
+# TODO: Remove `HOME="/opt"` once Quarto supports custom install locations
+# for TinyTeX, see https://github.com/quarto-dev/quarto-cli/issues/11800.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN {{ quarto.github_token_secret_mount() }} \
-    {{ quarto.install_tinytex_command("/lib/rstudio-server/bin/quarto/bin/quarto", True, home_path="/opt") }} \
+RUN {{ quarto.install_tinytex_command("/lib/rstudio-server/bin/quarto/bin/quarto", update_path=True, home_path="/opt") }} \
     && rm -f /tmp/tinytex-release.json
 {%- endif %}
 

--- a/workbench/template/test/goss.yaml.jinja2
+++ b/workbench/template/test/goss.yaml.jinja2
@@ -126,6 +126,18 @@ file:
   /usr/local/bin/quarto:
     exists: true
     filetype: symlink
+  # TinyTeX is installed under /opt/.TinyTeX (via HOME="/opt") so non-root runtime
+  # users can read the install; tlmgr path add symlinks the binaries into
+  # /usr/local/bin so they are on PATH.
+  /opt/.TinyTeX:
+    exists: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}{% endraw %}
+    filetype: directory
+  /usr/local/bin/tlmgr:
+    exists: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}{% endraw %}
+    filetype: symlink
+  /usr/local/bin/pdflatex:
+    exists: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}{% endraw %}
+    filetype: symlink
   # Check for R installation
 {% for r_version in Dependencies.R %}
   {{ r.get_version_directory(r_version) }}/bin/R:
@@ -224,5 +236,21 @@ command:
     exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
-      - "/tinytex\\s+Up to date/"
+      # "External Installation" is reported because TinyTeX is installed under
+      # HOME="/opt" so Quarto does not consider it one of its managed installs.
+      # TODO: Switch back to "Up to date" once Quarto supports a custom TinyTeX
+      # install location, see https://github.com/quarto-dev/quarto-cli/issues/11800.
+      - "/tinytex\\s+External Installation/"
+    skip: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}{% endraw %}
+  "Verify TinyTeX is readable and executable by a non-root user":
+    # Runs tlmgr and pdflatex as `nobody` to confirm the /opt/.TinyTeX install
+    # is accessible to non-root. `command -v` also forces PATH resolution,
+    # not just direct invocation — proves the /usr/local/bin symlinks are on
+    # the user's PATH. Guards against regressions in placement, permissions,
+    # or PATH setup.
+    exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' nobody
+    exit-status: 0
+    stdout:
+      - "tlmgr"
+      - "pdfTeX"
     skip: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}{% endraw %}


### PR DESCRIPTION
## Summary

Switch `workbench-session` to install Quarto via `apt-get install quarto={version}` from the [Posit Open apt repository](https://dl.posit.co/public/open/), using the updated `quarto.install()` macro from posit-dev/images-shared.

**Requires posit-dev/images-shared#479.**

## Why

- Avoids `${TARGETARCH}` URL construction. Posit publishes `quarto` as a multi-arch deb (amd64 + arm64) on both `jammy` and `noble`.
- dpkg owns the install, so goss `package.quarto.versions` assertions work directly without path-based proxies.
- No tarball extraction.

## Changes

The `quarto` deb installs to a flat `/opt/quarto/` directory (binary at `/opt/quarto/bin/quarto`) and symlinks `/usr/local/bin/quarto` via its postinst script. Downstream consequences in this repo:

- **Drop the redundant `quarto.symlink_binary(...)` call** in `workbench-session/template/Containerfile.ubuntu*.jinja2` — the deb's postinst already creates the `/usr/local/bin/quarto` symlink.
- **Install `xz-utils` explicitly** in the TinyTeX RUN; it is needed to unpack the TinyTeX `.tar.xz` archive and was previously pulled in transitively by the tarball install.
- **Update goss** path check from `/opt/quarto/{version}` to `/opt/quarto/bin/quarto` and add a `package.quarto.versions` check (now possible because the install is dpkg-tracked).

### Not affected

`workbench` (as distinct from `workbench-session`) bundles Quarto with `rstudio-server` and uses `quarto.install_tinytex_command(...)` against that bundled binary. That flow is unchanged.

## Test plan

- [x] CI builds the workbench-session matrix (Ubuntu 22.04 / 24.04 × R × Python combinations)
- [x] goss tests pass for all matrix combinations