### PR TITLE
Update Jupyter installs to use macro

### DIFF
--- a/workbench-session/matrix/Containerfile.ubuntu2204
+++ b/workbench-session/matrix/Containerfile.ubuntu2204
@@ -54,6 +54,7 @@ RUN /opt/python/$PYTHON_VERSION/bin/python -m venv /opt/python/jupyter && \
         notebook \
         "pwb_jupyterlab<2" && \
     rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests && \
+    rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/galata && \
     rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \
     ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
 

--- a/workbench-session/matrix/Containerfile.ubuntu2204
+++ b/workbench-session/matrix/Containerfile.ubuntu2204
@@ -49,7 +49,12 @@ COPY --from=python-builder /opt/python /opt/python
 ### Install Jupyter ###
 RUN /opt/python/$PYTHON_VERSION/bin/python -m venv /opt/python/jupyter && \
     /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    /opt/python/jupyter/bin/pip install --no-cache-dir 'jupyterlab<5' notebook 'pwb_jupyterlab<2' && \
+    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade --break-system-packages \
+        jupyterlab<5 \
+        notebook \
+        pwb_jupyterlab<2 && \
+    rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests && \
+    rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \
     ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
 
 ### Install Jupyter kernel ###

--- a/workbench-session/matrix/Containerfile.ubuntu2204
+++ b/workbench-session/matrix/Containerfile.ubuntu2204
@@ -49,10 +49,10 @@ COPY --from=python-builder /opt/python /opt/python
 ### Install Jupyter ###
 RUN /opt/python/$PYTHON_VERSION/bin/python -m venv /opt/python/jupyter && \
     /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade --break-system-packages \
-        jupyterlab<5 \
+    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade \
+        "jupyterlab<5" \
         notebook \
-        pwb_jupyterlab<2 && \
+        "pwb_jupyterlab<2" && \
     rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests && \
     rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \
     ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter

--- a/workbench-session/matrix/Containerfile.ubuntu2404
+++ b/workbench-session/matrix/Containerfile.ubuntu2404
@@ -61,10 +61,10 @@ COPY --from=python-builder /opt/python /opt/python
 ### Install Jupyter ###
 RUN /opt/python/$PYTHON_VERSION/bin/python -m venv /opt/python/jupyter && \
     /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade --break-system-packages \
-        jupyterlab<5 \
+    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade \
+        "jupyterlab<5" \
         notebook \
-        pwb_jupyterlab<2 && \
+        "pwb_jupyterlab<2" && \
     rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests && \
     rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \
     ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter

--- a/workbench-session/matrix/Containerfile.ubuntu2404
+++ b/workbench-session/matrix/Containerfile.ubuntu2404
@@ -61,7 +61,12 @@ COPY --from=python-builder /opt/python /opt/python
 ### Install Jupyter ###
 RUN /opt/python/$PYTHON_VERSION/bin/python -m venv /opt/python/jupyter && \
     /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    /opt/python/jupyter/bin/pip install --no-cache-dir 'jupyterlab<5' notebook 'pwb_jupyterlab<2' && \
+    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade --break-system-packages \
+        jupyterlab<5 \
+        notebook \
+        pwb_jupyterlab<2 && \
+    rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests && \
+    rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \
     ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
 
 ### Install Jupyter kernel ###

--- a/workbench-session/matrix/Containerfile.ubuntu2404
+++ b/workbench-session/matrix/Containerfile.ubuntu2404
@@ -66,6 +66,7 @@ RUN /opt/python/$PYTHON_VERSION/bin/python -m venv /opt/python/jupyter && \
         notebook \
         "pwb_jupyterlab<2" && \
     rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests && \
+    rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/galata && \
     rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \
     ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
 

--- a/workbench-session/template/Containerfile.ubuntu2204.jinja2
+++ b/workbench-session/template/Containerfile.ubuntu2204.jinja2
@@ -33,10 +33,7 @@ COPY {{ Path.Version }}/deps/ubuntu-22.04_packages.txt /tmp/ubuntu-22.04_package
 {{ python.copy_from_build_stage() }}
 
 ### Install Jupyter ###
-RUN {{ python.get_version_directory(python.build_arg()) }}/bin/python -m venv /opt/python/jupyter && \
-    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    /opt/python/jupyter/bin/pip install --no-cache-dir 'jupyterlab<5' notebook 'pwb_jupyterlab<2' && \
-    ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
+{{ python.run_install_jupyterlab_workbench(python.build_arg(), jupyterlab_version_pin = "<5", pwb_jupyterlab_version_pin = "<2") }}
 
 ### Install Jupyter kernel ###
 RUN {{ python.install_packages(python.build_arg(), "ipykernel") }} && \

--- a/workbench-session/template/Containerfile.ubuntu2404.jinja2
+++ b/workbench-session/template/Containerfile.ubuntu2404.jinja2
@@ -41,10 +41,7 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
 {{ python.copy_from_build_stage() }}
 
 ### Install Jupyter ###
-RUN {{ python.get_version_directory(python.build_arg()) }}/bin/python -m venv /opt/python/jupyter && \
-    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    /opt/python/jupyter/bin/pip install --no-cache-dir 'jupyterlab<5' notebook 'pwb_jupyterlab<2' && \
-    ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
+{{ python.run_install_jupyterlab_workbench(python.build_arg(), jupyterlab_version_pin = "<5", pwb_jupyterlab_version_pin = "<2") }}
 
 ### Install Jupyter kernel ###
 RUN {{ python.install_packages(python.build_arg(), "ipykernel") }} && \

--- a/workbench/2025.09/Containerfile.ubuntu2204.std
+++ b/workbench/2025.09/Containerfile.ubuntu2204.std
@@ -78,10 +78,10 @@ COPY --from=python-builder /opt/python /opt/python
 ### Install Jupyter ###
 RUN /opt/python/3.13.7/bin/python -m venv /opt/python/jupyter && \
     /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade --break-system-packages \
-        jupyterlab<5 \
+    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade \
+        "jupyterlab<5" \
         notebook \
-        pwb_jupyterlab<2 && \
+        "pwb_jupyterlab<2" && \
     rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests && \
     rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \
     ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter

--- a/workbench/2025.09/Containerfile.ubuntu2204.std
+++ b/workbench/2025.09/Containerfile.ubuntu2204.std
@@ -83,6 +83,7 @@ RUN /opt/python/3.13.7/bin/python -m venv /opt/python/jupyter && \
         notebook \
         "pwb_jupyterlab<2" && \
     rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests && \
+    rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/galata && \
     rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \
     ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
 

--- a/workbench/2025.09/Containerfile.ubuntu2204.std
+++ b/workbench/2025.09/Containerfile.ubuntu2204.std
@@ -78,7 +78,12 @@ COPY --from=python-builder /opt/python /opt/python
 ### Install Jupyter ###
 RUN /opt/python/3.13.7/bin/python -m venv /opt/python/jupyter && \
     /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    /opt/python/jupyter/bin/pip install --no-cache-dir 'jupyterlab<5' notebook 'pwb_jupyterlab<2' && \
+    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade --break-system-packages \
+        jupyterlab<5 \
+        notebook \
+        pwb_jupyterlab<2 && \
+    rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests && \
+    rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \
     ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
 
 ### Install Jupyter kernels ###

--- a/workbench/2025.09/Containerfile.ubuntu2404.std
+++ b/workbench/2025.09/Containerfile.ubuntu2404.std
@@ -78,10 +78,10 @@ COPY --from=python-builder /opt/python /opt/python
 ### Install Jupyter ###
 RUN /opt/python/3.13.7/bin/python -m venv /opt/python/jupyter && \
     /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade --break-system-packages \
-        jupyterlab<5 \
+    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade \
+        "jupyterlab<5" \
         notebook \
-        pwb_jupyterlab<2 && \
+        "pwb_jupyterlab<2" && \
     rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests && \
     rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \
     ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter

--- a/workbench/2025.09/Containerfile.ubuntu2404.std
+++ b/workbench/2025.09/Containerfile.ubuntu2404.std
@@ -83,6 +83,7 @@ RUN /opt/python/3.13.7/bin/python -m venv /opt/python/jupyter && \
         notebook \
         "pwb_jupyterlab<2" && \
     rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests && \
+    rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/galata && \
     rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \
     ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
 

--- a/workbench/2025.09/Containerfile.ubuntu2404.std
+++ b/workbench/2025.09/Containerfile.ubuntu2404.std
@@ -78,7 +78,12 @@ COPY --from=python-builder /opt/python /opt/python
 ### Install Jupyter ###
 RUN /opt/python/3.13.7/bin/python -m venv /opt/python/jupyter && \
     /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    /opt/python/jupyter/bin/pip install --no-cache-dir 'jupyterlab<5' notebook 'pwb_jupyterlab<2' && \
+    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade --break-system-packages \
+        jupyterlab<5 \
+        notebook \
+        pwb_jupyterlab<2 && \
+    rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests && \
+    rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \
     ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
 
 ### Install Jupyter kernels ###

--- a/workbench/2026.01/Containerfile.ubuntu2204.std
+++ b/workbench/2026.01/Containerfile.ubuntu2204.std
@@ -83,6 +83,7 @@ RUN /opt/python/3.14.2/bin/python -m venv /opt/python/jupyter && \
         notebook \
         "pwb_jupyterlab<2" && \
     rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests && \
+    rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/galata && \
     rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \
     ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
 

--- a/workbench/2026.01/Containerfile.ubuntu2204.std
+++ b/workbench/2026.01/Containerfile.ubuntu2204.std
@@ -78,7 +78,12 @@ COPY --from=python-builder /opt/python /opt/python
 ### Install Jupyter ###
 RUN /opt/python/3.14.2/bin/python -m venv /opt/python/jupyter && \
     /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    /opt/python/jupyter/bin/pip install --no-cache-dir 'jupyterlab<5' notebook 'pwb_jupyterlab<2' && \
+    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade --break-system-packages \
+        jupyterlab<5 \
+        notebook \
+        pwb_jupyterlab<2 && \
+    rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests && \
+    rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \
     ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
 
 ### Install Jupyter kernels ###

--- a/workbench/2026.01/Containerfile.ubuntu2204.std
+++ b/workbench/2026.01/Containerfile.ubuntu2204.std
@@ -78,10 +78,10 @@ COPY --from=python-builder /opt/python /opt/python
 ### Install Jupyter ###
 RUN /opt/python/3.14.2/bin/python -m venv /opt/python/jupyter && \
     /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade --break-system-packages \
-        jupyterlab<5 \
+    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade \
+        "jupyterlab<5" \
         notebook \
-        pwb_jupyterlab<2 && \
+        "pwb_jupyterlab<2" && \
     rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests && \
     rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \
     ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter

--- a/workbench/2026.01/Containerfile.ubuntu2404.std
+++ b/workbench/2026.01/Containerfile.ubuntu2404.std
@@ -83,6 +83,7 @@ RUN /opt/python/3.14.2/bin/python -m venv /opt/python/jupyter && \
         notebook \
         "pwb_jupyterlab<2" && \
     rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests && \
+    rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/galata && \
     rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \
     ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
 

--- a/workbench/2026.01/Containerfile.ubuntu2404.std
+++ b/workbench/2026.01/Containerfile.ubuntu2404.std
@@ -78,7 +78,12 @@ COPY --from=python-builder /opt/python /opt/python
 ### Install Jupyter ###
 RUN /opt/python/3.14.2/bin/python -m venv /opt/python/jupyter && \
     /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    /opt/python/jupyter/bin/pip install --no-cache-dir 'jupyterlab<5' notebook 'pwb_jupyterlab<2' && \
+    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade --break-system-packages \
+        jupyterlab<5 \
+        notebook \
+        pwb_jupyterlab<2 && \
+    rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests && \
+    rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \
     ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
 
 ### Install Jupyter kernels ###

--- a/workbench/2026.01/Containerfile.ubuntu2404.std
+++ b/workbench/2026.01/Containerfile.ubuntu2404.std
@@ -78,10 +78,10 @@ COPY --from=python-builder /opt/python /opt/python
 ### Install Jupyter ###
 RUN /opt/python/3.14.2/bin/python -m venv /opt/python/jupyter && \
     /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade --break-system-packages \
-        jupyterlab<5 \
+    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade \
+        "jupyterlab<5" \
         notebook \
-        pwb_jupyterlab<2 && \
+        "pwb_jupyterlab<2" && \
     rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests && \
     rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \
     ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter

--- a/workbench/template/Containerfile.ubuntu2204.jinja2
+++ b/workbench/template/Containerfile.ubuntu2204.jinja2
@@ -69,10 +69,7 @@ RUN ln -s /lib/rstudio-server/bin/quarto/bin/quarto /usr/local/bin/quarto
 {{ python.copy_from_build_stage() }}
 
 ### Install Jupyter ###
-RUN {{ python.get_version_directory(Dependencies.python.0) }}/bin/python -m venv /opt/python/jupyter && \
-    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    /opt/python/jupyter/bin/pip install --no-cache-dir 'jupyterlab<5' notebook 'pwb_jupyterlab<2' && \
-    ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
+{{ python.run_install_jupyterlab_workbench(Dependencies.python.0, jupyterlab_version_pin = "<5", pwb_jupyterlab_version_pin = "<2") }}
 
 ### Install Jupyter kernels ###
 {% for python_version in Dependencies.python -%}

--- a/workbench/template/Containerfile.ubuntu2404.jinja2
+++ b/workbench/template/Containerfile.ubuntu2404.jinja2
@@ -69,10 +69,7 @@ RUN ln -s /lib/rstudio-server/bin/quarto/bin/quarto /usr/local/bin/quarto
 {{ python.copy_from_build_stage() }}
 
 ### Install Jupyter ###
-RUN {{ python.get_version_directory(Dependencies.python.0) }}/bin/python -m venv /opt/python/jupyter && \
-    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    /opt/python/jupyter/bin/pip install --no-cache-dir 'jupyterlab<5' notebook 'pwb_jupyterlab<2' && \
-    ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
+{{ python.run_install_jupyterlab_workbench(Dependencies.python.0, jupyterlab_version_pin = "<5", pwb_jupyterlab_version_pin = "<2") }}
 
 ### Install Jupyter kernels ###
 {% for python_version in Dependencies.python -%}


### PR DESCRIPTION
Depends on https://github.com/posit-dev/images-shared/pull/474

- Updates Jupyter installs to use shared macro
- Remove tests/ and staging/yarn.lock from Jupyter package to fix vulnerabilities