### PR TITLE
Move lint job to PR workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,6 +15,7 @@ jobs:
     permissions: {}
     timeout-minutes: 10
     needs:
+      - lint
       - production
       - development
       - session
@@ -23,6 +24,23 @@ jobs:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: "3.x"
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
+        env:
+          SKIP: no-commit-to-branch
 
   production:
     name: Production

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -28,7 +28,6 @@ jobs:
     permissions: {}
     timeout-minutes: 10
     needs:
-      - lint
       - build
 
     steps:
@@ -42,23 +41,6 @@ jobs:
         with:
           result: ${{ steps.alls-green.outcome }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
-        with:
-          python-version: "3.x"
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
-        env:
-          SKIP: no-commit-to-branch
 
   build:
     name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,6 @@ on:
 jobs:
   release:
     if: github.event_name == 'workflow_dispatch'
-    timeout-minutes: 10
     permissions:
       contents: write
       pull-requests: write

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -6,4 +6,3 @@ rules:
         # are kept at @main intentionally.
         "posit-dev/images-shared/*": ref-pin
         "*": hash-pin
-


### PR DESCRIPTION
## Summary

- Moves the pre-commit lint job from `production.yml` to `pr.yml`
- Removes the now-dead lint job from `production.yml`

When PR builds were split into a dedicated `pr.yml` using `bakery-build-pr.yml`, the lint job was left behind in `production.yml`. Since `production.yml` no longer triggers on `pull_request` events, lint was not running on PRs.

## Test plan

- [ ] PR workflow runs lint, build, and zizmor jobs
- [ ] Production workflow still runs build on push-to-main without lint