### PR TITLE
Exclude wait-for-it.sh from shellcheck

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,7 @@ repos:
     hooks:
     -   id: shellcheck
         args: ["-s", "bash"]
+        exclude: "wait-for-it\\.sh$"
 -   repo: https://github.com/rhysd/actionlint
     rev: v1.7.12
     hooks:


### PR DESCRIPTION
## Summary
- Adds an `exclude` pattern to the shellcheck pre-commit hook to skip `wait-for-it.sh`
- `wait-for-it.sh` is a vendored third-party script, so shellcheck findings there are not actionable

## Test plan
- [ ] Verify `pre-commit run shellcheck --all-files` no longer flags `wait-for-it.sh`