### PR TITLE
Install pro-drivers on all architectures

### DIFF
--- a/workbench-session/matrix/Containerfile.ubuntu2404
+++ b/workbench-session/matrix/Containerfile.ubuntu2404
@@ -44,16 +44,12 @@ RUN apt-get update -yqq && \
     rm -rf /var/lib/apt/lists/*
 
 ### Install Pro Drivers ###
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        apt-get update -yqq && \
-        apt-get install -yqq --no-install-recommends \
-            rstudio-drivers && \
-        apt-get clean -yqq && \
-        rm -rf /var/lib/apt/lists/* && \
-        cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini; \
-    else \
-        echo "Pro Drivers will not be installed for architecture: $TARGETARCH"; \
-    fi
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        rstudio-drivers && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 # Install Python from previous stage
 COPY --from=python-builder /opt/python /opt/python

--- a/workbench-session/template/Containerfile.ubuntu2404.jinja2
+++ b/workbench-session/template/Containerfile.ubuntu2404.jinja2
@@ -30,12 +30,8 @@ COPY {{ Path.Version }}/deps/ubuntu-24.04_packages.txt /tmp/ubuntu-24.04_package
 {{ apt.run_install(files = '/tmp/ubuntu-24.04_packages.txt') }}
 
 ### Install Pro Drivers ###
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        {{ apt.install(packages="rstudio-drivers") | indent(8) }} && \
-        cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini; \
-    else \
-        echo "Pro Drivers will not be installed for architecture: $TARGETARCH"; \
-    fi
+{{ apt.run_install(packages="rstudio-drivers") }}
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 # Install Python from previous stage
 {{ python.copy_from_build_stage() }}

--- a/workbench/2025.09/Containerfile.ubuntu2404.std
+++ b/workbench/2025.09/Containerfile.ubuntu2404.std
@@ -93,16 +93,12 @@ RUN /opt/python/3.13.7/bin/pip install --no-cache-dir --upgrade --break-system-p
     /opt/python/3.13.7/bin/python -m ipykernel install --user --name python3.13.7 --display-name "Python 3.13.7"
 
 ### Install Pro Drivers ###
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        apt-get update -yqq && \
-        apt-get install -yqq --no-install-recommends \
-            rstudio-drivers && \
-        apt-get clean -yqq && \
-        rm -rf /var/lib/apt/lists/* && \
-        cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini; \
-    else \
-        echo "Pro Drivers will not be installed for architecture: $TARGETARCH"; \
-    fi
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        rstudio-drivers && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Copy startup scripts ###
 COPY --chmod=0775 "workbench/2025.09/scripts/startup.sh" /usr/local/bin/startup.sh

--- a/workbench/2026.01/Containerfile.ubuntu2404.std
+++ b/workbench/2026.01/Containerfile.ubuntu2404.std
@@ -93,16 +93,12 @@ RUN /opt/python/3.14.2/bin/pip install --no-cache-dir --upgrade --break-system-p
     /opt/python/3.14.2/bin/python -m ipykernel install --user --name python3.14.2 --display-name "Python 3.14.2"
 
 ### Install Pro Drivers ###
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        apt-get update -yqq && \
-        apt-get install -yqq --no-install-recommends \
-            rstudio-drivers && \
-        apt-get clean -yqq && \
-        rm -rf /var/lib/apt/lists/* && \
-        cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini; \
-    else \
-        echo "Pro Drivers will not be installed for architecture: $TARGETARCH"; \
-    fi
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        rstudio-drivers && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Copy startup scripts ###
 COPY --chmod=0775 "workbench/2026.01/scripts/startup.sh" /usr/local/bin/startup.sh

--- a/workbench/2026.04/Containerfile.ubuntu2404.std
+++ b/workbench/2026.04/Containerfile.ubuntu2404.std
@@ -57,8 +57,7 @@ RUN apt-get update -yqq && \
 
 
 ### Install wait-for-it ###
-RUN curl -fsSL -o /usr/local/bin/wait-for-it.sh https://raw.githubusercontent.com/rstudio/wait-for-it/master/wait-for-it.sh && \
-    chmod +x /usr/local/bin/wait-for-it.sh
+COPY --chmod=0755 workbench/scripts/wait-for-it.sh /usr/local/bin/wait-for-it.sh
 
 ### Install Workbench 2026.04.0+526.pro2 ###
 COPY --chmod=0755 workbench/2026.04/scripts/install_workbench.sh /tmp/install_workbench.sh
@@ -88,16 +87,12 @@ RUN /opt/python/3.14.4/bin/pip install --no-cache-dir --upgrade --break-system-p
     /opt/python/3.14.4/bin/python -m ipykernel install --user --name python3.14.4 --display-name "Python 3.14.4"
 
 ### Install Pro Drivers ###
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        apt-get update -yqq && \
-        apt-get install -yqq --no-install-recommends \
-            rstudio-drivers && \
-        apt-get clean -yqq && \
-        rm -rf /var/lib/apt/lists/* && \
-        cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini; \
-    else \
-        echo "Pro Drivers will not be installed for architecture: $TARGETARCH"; \
-    fi
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        rstudio-drivers && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Copy startup scripts ###
 COPY --chmod=0775 "workbench/2026.04/scripts/startup.sh" /usr/local/bin/startup.sh

--- a/workbench/template/Containerfile.ubuntu2404.jinja2
+++ b/workbench/template/Containerfile.ubuntu2404.jinja2
@@ -79,12 +79,8 @@ RUN {{ python.install_packages(python_version, "ipykernel") }} && \
 {% endfor -%}
 
 ### Install Pro Drivers ###
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        {{ apt.install(packages="rstudio-drivers") | indent(8) }} && \
-        cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini; \
-    else \
-        echo "Pro Drivers will not be installed for architecture: $TARGETARCH"; \
-    fi
+{{ apt.run_install(packages="rstudio-drivers") }}
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 {%- endif %}
 
 ### Copy startup scripts ###


### PR DESCRIPTION
## Summary

- Remove the `TARGETARCH` conditional that skipped `rstudio-drivers` installation on non-amd64 in `workbench` and `workbench-session` ubuntu2404 templates
- Use `apt.run_install()` consistently for driver installation
- Re-render affected Containerfiles

The `rstudio-drivers` package is now available on Cloudsmith for ARM, so the arch-gating is no longer needed.

Companion to https://github.com/posit-dev/images-connect/pull/78
Mentioned in https://github.com/posit-dev/images-workbench/issues/425