### PR TITLE
Trigger images-specialized release on new product versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,3 +21,27 @@ jobs:
     secrets:
       APP_ID: ${{ secrets.WORKBENCH_IDE_RELEASE_APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.WORKBENCH_IDE_RELEASE_PEM }}
+
+  trigger-specialized:
+    needs: release
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
+        with:
+          app-id: ${{ secrets.WORKBENCH_IDE_RELEASE_APP_ID }}
+          private-key: ${{ secrets.WORKBENCH_IDE_RELEASE_PEM }}
+          owner: posit-dev
+          repositories: images-specialized
+
+      - name: Trigger images-specialized release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          gh workflow run release.yml \
+            --repo posit-dev/images-specialized \
+            --ref main \
+            -f version="$VERSION"


### PR DESCRIPTION
## Summary
- Adds a `trigger-specialized` job to `.github/workflows/release.yml` that runs after the upstream `release` job and dispatches `release.yml` in `posit-dev/images-specialized` with the same `version` input.
- Mints a GitHub App token scoped to `images-specialized` so the dispatch is authorized without sharing tokens across repos.

## Dependencies
- Depends on https://github.com/posit-dev/images-specialized/pull/12 — the specialized repo's release workflow must be in place on `main` before this trigger has anything to call.
- Requires the `WORKBENCH_IDE_RELEASE_APP_ID` GitHub App to be installed on `posit-dev/images-specialized` with `actions: write`.

## Test plan
- [ ] Merge https://github.com/posit-dev/images-specialized/pull/12 first
- [ ] Confirm the GitHub App is installed on `images-specialized` with `actions: write`
- [ ] Manually dispatch this Release workflow with a test version and verify the specialized release workflow is triggered with the same input

🤖 Generated with [Claude Code](https://claude.com/claude-code)