### PR TITLE
Remove preview disclaimer from READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@ Container images for [Workbench](https://docs.posit.co/ide/server-pro).
 [![Session Image CI Build Status](https://github.com/posit-dev/images-workbench/actions/workflows/session.yml/badge.svg?branch=main)](https://github.com/posit-dev/images-workbench/actions/workflows/session.yml)
 [![Latest Version](https://img.shields.io/docker/v/posit/workbench?sort=semver&label=latest)](https://hub.docker.com/r/posit/workbench/tags)
 
-> [!NOTE]
-> These images are in preview as Posit migrates container images from [rstudio/rstudio-docker-products](https://github.com/rstudio/rstudio-docker-products). The previous images remain supported.
-
 ## Prerequisites
 
 | Tool | Required for | Install                                                                                                                         |

--- a/workbench-positron-init/README.md
+++ b/workbench-positron-init/README.md
@@ -16,9 +16,6 @@ This container image is an init container for [Workbench](https://docs.posit.co/
 ![Docker Hub Pulls](https://img.shields.io/docker/pulls/posit/workbench-positron-init)
 ![Docker Image Size](https://img.shields.io/docker/image-size/posit/workbench-positron-init/latest)
 
-> [!NOTE]
-> These images are in preview as Posit migrates container images from <a href="https://github.com/rstudio/rstudio-docker-products">rstudio/rstudio-docker-products</a>. The <a href="https://github.com/rstudio/rstudio-docker-products">rstudio-docker-products</a> images remain supported.
-
 > [!TIP]
 > Deploying on Kubernetes? Try the <a href="https://docs.posit.co/helm/charts/rstudio-workbench/README.html">Posit Workbench Helm chart</a>!
 

--- a/workbench-session-init/README.md
+++ b/workbench-session-init/README.md
@@ -16,9 +16,6 @@ This container image is an init container for Workbench. It stages the Workbench
 ![Docker Hub Pulls](https://img.shields.io/docker/pulls/posit/workbench-session-init)
 ![Docker Image Size](https://img.shields.io/docker/image-size/posit/workbench-session-init/latest)
 
-> [!NOTE]
-> These images are in preview as Posit migrates container images from <a href="https://github.com/rstudio/rstudio-docker-products">rstudio/rstudio-docker-products</a>. The <a href="https://github.com/rstudio/rstudio-docker-products">rstudio-docker-products</a> images remain supported.
-
 > [!TIP]
 > Deploying on Kubernetes? Try the <a href="https://docs.posit.co/helm/charts/rstudio-workbench/README.html">Posit Workbench Helm chart</a>, which can configure Workbench to launch sessions with this image.
 

--- a/workbench-session/README.md
+++ b/workbench-session/README.md
@@ -16,9 +16,6 @@ These container images provide the session runtime environments for [Workbench](
 ![Docker Hub Pulls](https://img.shields.io/docker/pulls/posit/workbench-session)
 ![Docker Image Size](https://img.shields.io/docker/image-size/posit/workbench-session/latest)
 
-> [!NOTE]
-> These images are in preview as Posit migrates container images from <a href="https://github.com/rstudio/rstudio-docker-products">rstudio/rstudio-docker-products</a>. The previous `rstudio/workbench-session` and `rstudio/r-session-complete` images remain supported.
-
 > [!TIP]
 > Deploying on Kubernetes? Try the <a href="https://docs.posit.co/helm/charts/rstudio-workbench/README.html">Posit Workbench Helm chart</a>!
 

--- a/workbench/README.md
+++ b/workbench/README.md
@@ -16,9 +16,6 @@ This container image provides [Workbench](https://docs.posit.co/ide/server-pro/)
 ![Docker Hub Pulls](https://img.shields.io/docker/pulls/posit/workbench)
 ![Docker Image Size](https://img.shields.io/docker/image-size/posit/workbench/latest)
 
-> [!NOTE]
-> These images are in preview as Posit migrates container images from <a href="https://github.com/rstudio/rstudio-docker-products">rstudio/rstudio-docker-products</a>. The previous images remain supported.
-
 > [!TIP]
 > Deploying on Kubernetes? Try the <a href="https://docs.posit.co/helm/charts/rstudio-workbench/README.html">Posit Workbench Helm chart</a>!
 


### PR DESCRIPTION
## Summary

- Remove the "in preview" callout from the top-level README and the `workbench`, `workbench-session`, `workbench-session-init`, `workbench-positron-init` READMEs now that the Posit container images are generally available.
- Fix the Posit Community Forum link in the four image READMEs to point at the Workbench subcategory (`/c/posit-professional-hosted/posit-workbench/69`) instead of the parent category, matching Connect and Package Manager.

Refs posit-dev/images-shared#329.