### PR TITLE
Restagger crons: 03:45 session, 09:45 daily

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -12,8 +12,11 @@ on:
         type: string
 
   schedule:
-    # Hourly rebuild of dev images
-    - cron: "45 4 * * *" # At 04:45 every day
+    # Daily rebuild of dev images. Staggered with images-package-manager
+    # (07:45) and images-connect (08:45) so the three products don't
+    # all build in the same hour. Weeklies run at 01–03 UTC, dailies at
+    # 07–09 UTC, with 04–06 UTC reserved as growth headroom.
+    - cron: "45 9 * * *" # At 09:45 every day
 
   push:
     branches:

--- a/.github/workflows/session.yml
+++ b/.github/workflows/session.yml
@@ -4,7 +4,9 @@ on:
 
   schedule:
     # Weekly rebuild of all images, to pick up any upstream changes.
-    - cron: "15 4 * * 0" # At 04:15 on Sunday
+    # Runs in the same hour as Workbench production (03:15 Sun) but at
+    # minute 45 so the session matrix follows the main Workbench rebuild.
+    - cron: "45 3 * * 0" # At 03:45 on Sunday
 
   push:
     branches:


### PR DESCRIPTION
Restagger this repo's crons into the wider weekly + daily schedule agreed across images-* (PPM/Connect/Workbench). Workbench takes the last slot in both windows.

- `development.yml`: `45 6 * * *` → `45 9 * * *` (daily 06:45 → 09:45)
- `session.yml`: `15 4 * * 0` → `45 3 * * 0` (matrix 04:15 → 03:45, same hour as Workbench prod but later in the hour so session follows the main rebuild)
- `production.yml` unchanged (stays at 03:15 Sun — Workbench is already in the last weekly hour)

Window layout:
- Weeklies at 01–03 UTC Sun
- 04–06 UTC reserved as growth headroom
- Dailies at 07–09 UTC

Part of posit-dev/images-shared#280.