### PR TITLE
Assert recursive file permissions on session image trees

### DIFF
--- a/workbench-positron-init/matrix/test/goss.yaml
+++ b/workbench-positron-init/matrix/test/goss.yaml
@@ -13,3 +13,11 @@ file:
     exists: true
     filetype: file
     mode: "0755"
+
+command:
+  positron-files-other-read:
+    exec: 'find /opt/positron -type f -not -perm -004 -print 2>&1 | head -c1 | (! grep -q .)'
+    exit-status: 0
+  positron-dirs-other-rx:
+    exec: 'find /opt/positron -type d -not -perm -005 -print 2>&1 | head -c1 | (! grep -q .)'
+    exit-status: 0

--- a/workbench-positron-init/template/test/goss.yaml
+++ b/workbench-positron-init/template/test/goss.yaml
@@ -13,3 +13,11 @@ file:
     exists: true
     filetype: file
     mode: "0755"
+
+command:
+  positron-files-other-read:
+    exec: 'find /opt/positron -type f -not -perm -004 -print 2>&1 | head -c1 | (! grep -q .)'
+    exit-status: 0
+  positron-dirs-other-rx:
+    exec: 'find /opt/positron -type d -not -perm -005 -print 2>&1 | head -c1 | (! grep -q .)'
+    exit-status: 0

--- a/workbench-session-init/2025.09/test/goss.yaml
+++ b/workbench-session-init/2025.09/test/goss.yaml
@@ -95,3 +95,11 @@ file:
     exists: true
     filetype: file
     mode: "0755"
+
+command:
+  session-components-files-other-read:
+    exec: 'find /opt/session-components -type f -not -perm -004 -print 2>&1 | head -c1 | (! grep -q .)'
+    exit-status: 0
+  session-components-dirs-other-rx:
+    exec: 'find /opt/session-components -type d -not -perm -005 -print 2>&1 | head -c1 | (! grep -q .)'
+    exit-status: 0

--- a/workbench-session-init/2026.01/test/goss.yaml
+++ b/workbench-session-init/2026.01/test/goss.yaml
@@ -95,3 +95,11 @@ file:
     exists: true
     filetype: file
     mode: "0755"
+
+command:
+  session-components-files-other-read:
+    exec: 'find /opt/session-components -type f -not -perm -004 -print 2>&1 | head -c1 | (! grep -q .)'
+    exit-status: 0
+  session-components-dirs-other-rx:
+    exec: 'find /opt/session-components -type d -not -perm -005 -print 2>&1 | head -c1 | (! grep -q .)'
+    exit-status: 0

--- a/workbench-session-init/2026.04/test/goss.yaml
+++ b/workbench-session-init/2026.04/test/goss.yaml
@@ -95,3 +95,11 @@ file:
     exists: true
     filetype: file
     mode: "0755"
+
+command:
+  session-components-files-other-read:
+    exec: 'find /opt/session-components -type f -not -perm -004 -print 2>&1 | head -c1 | (! grep -q .)'
+    exit-status: 0
+  session-components-dirs-other-rx:
+    exec: 'find /opt/session-components -type d -not -perm -005 -print 2>&1 | head -c1 | (! grep -q .)'
+    exit-status: 0

--- a/workbench-session-init/template/test/goss.yaml.jinja2
+++ b/workbench-session-init/template/test/goss.yaml.jinja2
@@ -95,3 +95,11 @@ file:
     exists: true
     filetype: file
     mode: "0755"
+
+command:
+  session-components-files-other-read:
+    exec: 'find /opt/session-components -type f -not -perm -004 -print 2>&1 | head -c1 | (! grep -q .)'
+    exit-status: 0
+  session-components-dirs-other-rx:
+    exec: 'find /opt/session-components -type d -not -perm -005 -print 2>&1 | head -c1 | (! grep -q .)'
+    exit-status: 0

--- a/workbench-session/matrix/test/goss.yaml
+++ b/workbench-session/matrix/test/goss.yaml
@@ -30,6 +30,9 @@ file:
   /usr/local/bin/pdflatex:
     exists: true
     filetype: symlink
+  /opt:
+    exists: true
+    filetype: directory
 
 command:
   "Verify Jupyter Notebook works":
@@ -73,3 +76,9 @@ command:
     exit-status: 0
     stdout:
       - "/^quarto$/"
+  "Verify /opt files are world-readable":
+    exec: 'find /opt -type f -not -perm -004 -print 2>&1 | head -c1 | (! grep -q .)'
+    exit-status: 0
+  "Verify /opt directories are world-traversable":
+    exec: 'find /opt -type d -not -perm -005 -print 2>&1 | head -c1 | (! grep -q .)'
+    exit-status: 0

--- a/workbench-session/template/test/goss.yaml.jinja2
+++ b/workbench-session/template/test/goss.yaml.jinja2
@@ -37,6 +37,9 @@ file:
   /usr/local/bin/pdflatex:
     exists: true
     filetype: symlink
+  /opt:
+    exists: true
+    filetype: directory
 
 command:
   "Verify Jupyter Notebook works":
@@ -80,3 +83,9 @@ command:
     exit-status: 0
     stdout:
       - "/^quarto$/"
+  "Verify /opt files are world-readable":
+    exec: 'find /opt -type f -not -perm -004 -print 2>&1 | head -c1 | (! grep -q .)'
+    exit-status: 0
+  "Verify /opt directories are world-traversable":
+    exec: 'find /opt -type d -not -perm -005 -print 2>&1 | head -c1 | (! grep -q .)'
+    exit-status: 0


### PR DESCRIPTION
## Summary

Adds two goss `command:` assertions per image that walk the staged tree the non-root k8s session must read, and fail if any file is missing the world-read bit or any directory is missing world-traverse/read bits. The existing tests only spot-check explicit files — a deeply nested binary or data file shipped without world-readable permissions would silently break non-root sessions today.

- `workbench-session-init` — guards `/opt/session-components`
- `workbench-positron-init` — guards `/opt/positron`
- `workbench-session` — guards `/opt` (covers R, Python, and rstudio-drivers — the trees the non-root session reads); also adds the `/opt` directory existence assertion that was missing

Pattern:

```
find <path> -type f -not -perm -004 -print 2>&1 | head -c1 | (! grep -q .)
find <path> -type d -not -perm -005 -print 2>&1 | head -c1 | (! grep -q .)
```

`2>&1` is intentional — without it, `find` complaining about a renamed/missing target writes to stderr, the pipeline leaves stdout empty, and the assertion silently passes. Merging stderr into stdout makes such a regression visible.

## Notes

- Edits live in `template/test/`; rendered versions in `matrix/` and the version dirs were updated in lockstep. The additions sit in non-templated sections, so the manual sync matches what `bakery update files` would produce.
- The `workbench-session` goss file uses descriptive titles as keys, so the two new assertions follow that style (`"Verify /opt files are world-readable"` / `"Verify /opt directories are world-traversable"`). The two init images keep slug-style keys (`*-files-other-read` / `*-dirs-other-rx`) to match their existing patterns.

Mirrors [rstudio/rstudio-docker-products#1045](https://github.com/rstudio/rstudio-docker-products/pull/1045).

## Test plan

- [ ] CI: production workflow passes goss tests for `workbench-session-init`
- [ ] CI: development workflow passes goss tests for dev streams
- [ ] CI: session workflow passes goss tests for `workbench-session` matrix
- [ ] Confirm assertions fail on regression (e.g., `chmod 600` a nested file)