### PR TITLE
Slow dependabot actions group to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
       - "/"
       - "/.github/actions/*"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       actions:
         patterns:


### PR DESCRIPTION
Change the dependabot github-actions ecosystem schedule from weekly to monthly to reduce churn from action bumps.