### PR TITLE
Install posit-bakery from PyPI in justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -6,8 +6,10 @@ setup:
 
 install-bakery *OPTS:
   #!/bin/bash
-  # TODO: Update this after package is published somewhere
-  uv tool install {{OPTS}} 'git+ssh://git@github.com/posit-dev/images-shared.git@main#egg=posit-bakery&subdirectory=posit-bakery'
+  # Install the latest released posit-bakery from PyPI.
+  # For an unreleased development version, install from GitHub:
+  #   uv tool install 'git+ssh://git@github.com/posit-dev/images-shared.git@main#egg=posit-bakery&subdirectory=posit-bakery'
+  uv tool install {{OPTS}} posit-bakery
 
 install-goss:
   #!/bin/bash


### PR DESCRIPTION
## Summary
- Switch `just install-bakery` to install posit-bakery from PyPI (`uv tool install posit-bakery`) now that the package is published.
- Retain the previous `git+ssh://...` install command as an inline comment for installing unreleased development versions.

Depends on posit-dev/images-shared#532 landing and a posit-bakery release being published to PyPI.

## Test plan
- [ ] After a posit-bakery PyPI release exists, run \`just install-bakery\` locally and verify the latest released bakery is installed.
- [ ] Run \`just install-bakery --reinstall\` (\`OPTS\` passthrough still works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)