### PR TITLE
Mount GITHUB_TOKEN secret for TinyTeX install

### DIFF
--- a/workbench-session/matrix/Containerfile.ubuntu2204
+++ b/workbench-session/matrix/Containerfile.ubuntu2204
@@ -77,11 +77,7 @@ RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
 # ADD busts the cache on new TinyTeX releases.
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN apt-get update -yqq && \
-    apt-get install -yqq --no-install-recommends \
-        xz-utils && \
-    apt-get clean -yqq && \
-    rm -rf /var/lib/apt/lists/* && \
+RUN --mount=type=secret,id=github_token,required=false \
     GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 

--- a/workbench-session/matrix/Containerfile.ubuntu2404
+++ b/workbench-session/matrix/Containerfile.ubuntu2404
@@ -85,11 +85,7 @@ RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
 # ADD busts the cache on new TinyTeX releases.
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN apt-get update -yqq && \
-    apt-get install -yqq --no-install-recommends \
-        xz-utils && \
-    apt-get clean -yqq && \
-    rm -rf /var/lib/apt/lists/* && \
+RUN --mount=type=secret,id=github_token,required=false \
     GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --quiet --update-path && \
     rm -f /tmp/tinytex-release.json
 

--- a/workbench-session/matrix/test/goss.yaml
+++ b/workbench-session/matrix/test/goss.yaml
@@ -61,9 +61,7 @@ command:
     exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
-      # "External Installation" because Quarto doesn't recognize TinyTeX installed under HOME="/opt".
-      # TODO: Switch to "Up to date" once https://github.com/quarto-dev/quarto-cli/issues/11800 lands.
-      - "/tinytex\\s+External Installation/"
+      - "/tinytex\\s+Up to date/"
   "Verify TinyTeX is readable and executable by a non-root user":
     exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' nobody
     exit-status: 0

--- a/workbench-session/template/Containerfile.ubuntu2204.jinja2
+++ b/workbench-session/template/Containerfile.ubuntu2204.jinja2
@@ -47,7 +47,7 @@ RUN {{ quarto.install(quarto.build_arg()) | indent(4) }}
 # ADD busts the cache on new TinyTeX releases.
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN {{ apt.install(packages="xz-utils") | indent(4) }} && \
+RUN {{ quarto.github_token_secret_mount() }} \
     {{ quarto.install_tinytex_command(quarto.get_directory() ~ "/bin/quarto", update_path=True, home_path="/opt") | indent(4) }} && \
     rm -f /tmp/tinytex-release.json
 

--- a/workbench-session/template/Containerfile.ubuntu2404.jinja2
+++ b/workbench-session/template/Containerfile.ubuntu2404.jinja2
@@ -51,7 +51,7 @@ RUN {{ quarto.install(quarto.build_arg()) | indent(4) }}
 # ADD busts the cache on new TinyTeX releases.
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN {{ apt.install(packages="xz-utils") | indent(4) }} && \
+RUN {{ quarto.github_token_secret_mount() }} \
     {{ quarto.install_tinytex_command(quarto.get_directory() ~ "/bin/quarto", update_path=True, home_path="/opt") | indent(4) }} && \
     rm -f /tmp/tinytex-release.json
 

--- a/workbench-session/template/test/goss.yaml.jinja2
+++ b/workbench-session/template/test/goss.yaml.jinja2
@@ -68,9 +68,7 @@ command:
     exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
-      # "External Installation" because Quarto doesn't recognize TinyTeX installed under HOME="/opt".
-      # TODO: Switch to "Up to date" once https://github.com/quarto-dev/quarto-cli/issues/11800 lands.
-      - "/tinytex\\s+External Installation/"
+      - "/tinytex\\s+Up to date/"
   "Verify TinyTeX is readable and executable by a non-root user":
     exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' nobody
     exit-status: 0

--- a/workbench/2025.09/deps/ubuntu-22.04_optional_packages.txt
+++ b/workbench/2025.09/deps/ubuntu-22.04_optional_packages.txt
@@ -41,4 +41,5 @@ tk
 tk-dev
 tk-table
 unixodbc-dev
+xz-utils
 zlib1g-dev

--- a/workbench/2025.09/deps/ubuntu-24.04_optional_packages.txt
+++ b/workbench/2025.09/deps/ubuntu-24.04_optional_packages.txt
@@ -41,4 +41,5 @@ tk
 tk-dev
 tk-table
 unixodbc-dev
+xz-utils
 zlib1g-dev

--- a/workbench/2025.09/test/goss.yaml
+++ b/workbench/2025.09/test/goss.yaml
@@ -222,11 +222,7 @@ command:
     exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
-      # "External Installation" is reported because TinyTeX is installed under
-      # HOME="/opt" so Quarto does not consider it one of its managed installs.
-      # TODO: Switch back to "Up to date" once Quarto supports a custom TinyTeX
-      # install location, see https://github.com/quarto-dev/quarto-cli/issues/11800.
-      - "/tinytex\\s+External Installation/"
+      - "/tinytex\\s+Up to date/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Verify TinyTeX is readable and executable by a non-root user":
     # Runs tlmgr and pdflatex as `nobody` to confirm the /opt/.TinyTeX install

--- a/workbench/2026.01/deps/ubuntu-22.04_optional_packages.txt
+++ b/workbench/2026.01/deps/ubuntu-22.04_optional_packages.txt
@@ -41,5 +41,5 @@ tk
 tk-dev
 tk-table
 unixodbc-dev
-zlib1g-dev
 xz-utils
+zlib1g-dev

--- a/workbench/2026.01/deps/ubuntu-24.04_optional_packages.txt
+++ b/workbench/2026.01/deps/ubuntu-24.04_optional_packages.txt
@@ -41,5 +41,5 @@ tk
 tk-dev
 tk-table
 unixodbc-dev
-zlib1g-dev
 xz-utils
+zlib1g-dev

--- a/workbench/2026.01/test/goss.yaml
+++ b/workbench/2026.01/test/goss.yaml
@@ -222,11 +222,7 @@ command:
     exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
-      # "External Installation" is reported because TinyTeX is installed under
-      # HOME="/opt" so Quarto does not consider it one of its managed installs.
-      # TODO: Switch back to "Up to date" once Quarto supports a custom TinyTeX
-      # install location, see https://github.com/quarto-dev/quarto-cli/issues/11800.
-      - "/tinytex\\s+External Installation/"
+      - "/tinytex\\s+Up to date/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
   "Verify TinyTeX is readable and executable by a non-root user":
     # Runs tlmgr and pdflatex as `nobody` to confirm the /opt/.TinyTeX install

--- a/workbench/2026.04/deps/ubuntu-22.04_optional_packages.txt
+++ b/workbench/2026.04/deps/ubuntu-22.04_optional_packages.txt
@@ -41,5 +41,5 @@ tk
 tk-dev
 tk-table
 unixodbc-dev
-zlib1g-dev
 xz-utils
+zlib1g-dev

--- a/workbench/2026.04/deps/ubuntu-24.04_optional_packages.txt
+++ b/workbench/2026.04/deps/ubuntu-24.04_optional_packages.txt
@@ -41,5 +41,5 @@ tk
 tk-dev
 tk-table
 unixodbc-dev
-zlib1g-dev
 xz-utils
+zlib1g-dev

--- a/workbench/template/Containerfile.ubuntu2204.jinja2
+++ b/workbench/template/Containerfile.ubuntu2204.jinja2
@@ -113,7 +113,8 @@ RUN mkdir -p /var/lib/rstudio-server/monitor/log \
 # TODO: Remove `HOME="/opt"` once Quarto supports custom install locations
 # for TinyTeX, see https://github.com/quarto-dev/quarto-cli/issues/11800.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN {{ quarto.install_tinytex_command("/lib/rstudio-server/bin/quarto/bin/quarto", update_path=True, home_path="/opt") }} \
+RUN {{ quarto.github_token_secret_mount() }} \
+    {{ quarto.install_tinytex_command("/lib/rstudio-server/bin/quarto/bin/quarto", update_path=True, home_path="/opt") }} \
     && rm -f /tmp/tinytex-release.json
 {%- endif %}
 

--- a/workbench/template/Containerfile.ubuntu2404.jinja2
+++ b/workbench/template/Containerfile.ubuntu2404.jinja2
@@ -113,7 +113,8 @@ RUN mkdir -p /var/lib/rstudio-server/monitor/log \
 # TODO: Remove `HOME="/opt"` once Quarto supports custom install locations
 # for TinyTeX, see https://github.com/quarto-dev/quarto-cli/issues/11800.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN {{ quarto.install_tinytex_command("/lib/rstudio-server/bin/quarto/bin/quarto", update_path=True, home_path="/opt") }} \
+RUN {{ quarto.github_token_secret_mount() }} \
+    {{ quarto.install_tinytex_command("/lib/rstudio-server/bin/quarto/bin/quarto", update_path=True, home_path="/opt") }} \
     && rm -f /tmp/tinytex-release.json
 {%- endif %}
 

--- a/workbench/template/deps/ubuntu-22.04_optional_packages.txt.jinja2
+++ b/workbench/template/deps/ubuntu-22.04_optional_packages.txt.jinja2
@@ -41,5 +41,5 @@ tk
 tk-dev
 tk-table
 unixodbc-dev
-zlib1g-dev
 xz-utils
+zlib1g-dev

--- a/workbench/template/deps/ubuntu-24.04_optional_packages.txt.jinja2
+++ b/workbench/template/deps/ubuntu-24.04_optional_packages.txt.jinja2
@@ -41,5 +41,5 @@ tk
 tk-dev
 tk-table
 unixodbc-dev
-zlib1g-dev
 xz-utils
+zlib1g-dev

--- a/workbench/template/test/goss.yaml.jinja2
+++ b/workbench/template/test/goss.yaml.jinja2
@@ -236,11 +236,7 @@ command:
     exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
-      # "External Installation" is reported because TinyTeX is installed under
-      # HOME="/opt" so Quarto does not consider it one of its managed installs.
-      # TODO: Switch back to "Up to date" once Quarto supports a custom TinyTeX
-      # install location, see https://github.com/quarto-dev/quarto-cli/issues/11800.
-      - "/tinytex\\s+External Installation/"
+      - "/tinytex\\s+Up to date/"
     skip: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}{% endraw %}
   "Verify TinyTeX is readable and executable by a non-root user":
     # Runs tlmgr and pdflatex as `nobody` to confirm the /opt/.TinyTeX install


### PR DESCRIPTION
Commit https://github.com/posit-dev/images-workbench/commit/bc4ad7b regressed the workbench and workbench-session templates by dropping `quarto.github_token_secret_mount()` from the TinyTeX RUN block. Builds of workbench 2025.09 and 2026.01 Standard variants therefore hit GitHub's anonymous rate limits when quarto fetches tinytex releases from `rstudio/tinytex-releases`. The workbench-session matrix files referenced `/run/secrets/github_token` in the command but never declared the secret on the RUN, so `$GH_TOKEN` was always empty.

Restore the mount in the workbench and workbench-session templates and apply the same fix to the 2025.09 and 2026.01 std rendered Containerfiles and the workbench-session matrix files. 2026.04 std files already have the mount (rendered before the regression).

Also drops the redundant inline `apt.install xz-utils` from workbench-session (xz-utils is already in the matrix `packages.txt`) and adds `xz-utils` to workbench 2025.09 optional packages — TinyTeX needs xz to extract `.tar.xz` archives. The corresponding ordering fix puts `xz-utils` alphabetically between `unixodbc-dev` and `zlib1g-dev` across all affected rendered files and the template.

Related cleanup in images-connect:

- https://github.com/posit-dev/images-connect/pull/98