### PR TITLE
Configure apt retries in rendered Containerfiles

### DIFF
--- a/workbench-positron-init/matrix/Containerfile.ubuntu2404
+++ b/workbench-positron-init/matrix/Containerfile.ubuntu2404
@@ -9,7 +9,8 @@ ENV PWB_POSITRON_TARGET="positron,positron-docs"
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \
@@ -63,7 +64,8 @@ LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/workbench-session-init/2025.09/Containerfile.ubuntu2404
+++ b/workbench-session-init/2025.09/Containerfile.ubuntu2404
@@ -7,7 +7,8 @@ ARG TARGETARCH=${BUILDARCH}
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Initialize PTI in container ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/workbench-session-init/2026.01/Containerfile.ubuntu2404
+++ b/workbench-session-init/2026.01/Containerfile.ubuntu2404
@@ -7,7 +7,8 @@ ARG TARGETARCH=${BUILDARCH}
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Initialize PTI in container ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/workbench-session-init/2026.04/Containerfile.ubuntu2404
+++ b/workbench-session-init/2026.04/Containerfile.ubuntu2404
@@ -7,7 +7,8 @@ ARG TARGETARCH=${BUILDARCH}
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Initialize PTI in container ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/workbench-session/matrix/Containerfile.ubuntu2204
+++ b/workbench-session/matrix/Containerfile.ubuntu2204
@@ -22,7 +22,8 @@ ARG PYTHON_VERSION
 ARG QUARTO_VERSION
 
 ### Install Apt Packages ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/workbench-session/matrix/Containerfile.ubuntu2404
+++ b/workbench-session/matrix/Containerfile.ubuntu2404
@@ -22,7 +22,8 @@ ARG PYTHON_VERSION
 ARG QUARTO_VERSION
 
 ### Install Apt Packages ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/workbench/2025.09/Containerfile.ubuntu2204.min
+++ b/workbench/2025.09/Containerfile.ubuntu2204.min
@@ -23,7 +23,8 @@ ENV PWB_EXIT_AFTER_VERIFY=false
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/workbench/2025.09/Containerfile.ubuntu2204.std
+++ b/workbench/2025.09/Containerfile.ubuntu2204.std
@@ -31,7 +31,8 @@ ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/workbench/2025.09/Containerfile.ubuntu2404.min
+++ b/workbench/2025.09/Containerfile.ubuntu2404.min
@@ -23,7 +23,8 @@ ENV PWB_EXIT_AFTER_VERIFY=false
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/workbench/2025.09/Containerfile.ubuntu2404.std
+++ b/workbench/2025.09/Containerfile.ubuntu2404.std
@@ -31,7 +31,8 @@ ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/workbench/2026.01/Containerfile.ubuntu2204.min
+++ b/workbench/2026.01/Containerfile.ubuntu2204.min
@@ -23,7 +23,8 @@ ENV PWB_EXIT_AFTER_VERIFY=false
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/workbench/2026.01/Containerfile.ubuntu2204.std
+++ b/workbench/2026.01/Containerfile.ubuntu2204.std
@@ -31,7 +31,8 @@ ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/workbench/2026.01/Containerfile.ubuntu2404.min
+++ b/workbench/2026.01/Containerfile.ubuntu2404.min
@@ -23,7 +23,8 @@ ENV PWB_EXIT_AFTER_VERIFY=false
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/workbench/2026.01/Containerfile.ubuntu2404.std
+++ b/workbench/2026.01/Containerfile.ubuntu2404.std
@@ -31,7 +31,8 @@ ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/workbench/2026.04/Containerfile.ubuntu2204.min
+++ b/workbench/2026.04/Containerfile.ubuntu2204.min
@@ -23,7 +23,8 @@ ENV PWB_EXIT_AFTER_VERIFY=false
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/workbench/2026.04/Containerfile.ubuntu2204.std
+++ b/workbench/2026.04/Containerfile.ubuntu2204.std
@@ -33,7 +33,8 @@ ENV PWB_EXIT_AFTER_VERIFY=false
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/workbench/2026.04/Containerfile.ubuntu2404.min
+++ b/workbench/2026.04/Containerfile.ubuntu2404.min
@@ -23,7 +23,8 @@ ENV PWB_EXIT_AFTER_VERIFY=false
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/workbench/2026.04/Containerfile.ubuntu2404.std
+++ b/workbench/2026.04/Containerfile.ubuntu2404.std
@@ -33,7 +33,8 @@ ENV PWB_EXIT_AFTER_VERIFY=false
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \


### PR DESCRIPTION
## Why

Adds `Acquire::Retries=3` and `Acquire::http(s)::Timeout=30` to `/etc/apt/apt.conf.d/99-retries` at the top of each first apt RUN. Transient timeouts on `archive.ubuntu.com` and `ports.ubuntu.com` now recover on retry instead of failing the build.

Surgical edit to the rendered Containerfiles to avoid touching unrelated files. The macro change producing this output going forward landed upstream:

- https://github.com/posit-dev/images-shared/pull/538

In `workbench-positron-init`, the builder and build stages each FROM ubuntu independently, so the retries config is written in both stages.