### PR TITLE
Skip amd64-only session-init goss checks on arm64

### DIFF
--- a/workbench-session-init/template/test/goss.yaml.jinja2
+++ b/workbench-session-init/template/test/goss.yaml.jinja2
@@ -19,10 +19,6 @@ file:
     exists: true
     filetype: directory
     mode: "0755"
-  /opt/session-components/bin/opensuse15:
-    exists: true
-    filetype: directory
-    mode: "0755"
   /opt/session-components/bin/postback:
     exists: true
     filetype: directory
@@ -39,14 +35,26 @@ file:
     exists: true
     filetype: file
     mode: "0755"
-  /opt/session-components/bin/rhel8:
-    exists: true
-    filetype: directory
-    mode: "0755"
   /opt/session-components/bin/rhel9:
     exists: true
     filetype: directory
     mode: "0755"
+  /opt/session-components/bin/rhel10:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  # opensuse15 and rhel8 are only shipped in the amd64 build of the
+  # upstream rsp-session-multi-linux tarball.
+  {% raw %}{{- if eq .Env.IMAGE_OS_PLATFORM "linux/amd64" }}{% endraw %}
+  /opt/session-components/bin/opensuse15:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  /opt/session-components/bin/rhel8:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  {% raw %}{{- end }}{% endraw %}
   /opt/session-components/bin/shared-run:
     exists: true
     filetype: file


### PR DESCRIPTION
The upstream `rsp-session-multi-linux` tarball omits `opensuse15` and
`rhel8` on `linux/arm64`, failing the goss assertions on every arm64
dev build. Skip those two checks via a goss runtime conditional on
`IMAGE_OS_PLATFORM`, and add `rhel10` (present on both arches).

Quarto is left unconditional — its absence on arm64 is a regression
worth raising with the workbench team.