### PR TITLE
Assert Quarto binary path and symlink target

### DIFF
--- a/workbench/2025.09/test/goss.yaml
+++ b/workbench/2025.09/test/goss.yaml
@@ -110,10 +110,15 @@ file:
     contents:
       - "RSPM=https://p3m.dev/cran/__linux__/{{ .Env.IMAGE_OS_CODENAME }}/latest"
       - "CRAN=https://p3m.dev/cran/__linux__/{{ .Env.IMAGE_OS_CODENAME }}/latest"
-  # Check for symlinked Quarto executable
+  # Quarto is bundled with Workbench.
+  /lib/rstudio-server/bin/quarto/bin/quarto:
+    exists: true
+    filetype: file
+    mode: "0755"
   /usr/local/bin/quarto:
     exists: true
     filetype: symlink
+    linked-to: /lib/rstudio-server/bin/quarto/bin/quarto
   # TinyTeX is installed under /opt/.TinyTeX (via HOME="/opt") so non-root runtime
   # users can read the install; tlmgr path add symlinks the binaries into
   # /usr/local/bin so they are on PATH.

--- a/workbench/2026.01/test/goss.yaml
+++ b/workbench/2026.01/test/goss.yaml
@@ -110,10 +110,15 @@ file:
     contents:
       - "RSPM=https://p3m.dev/cran/__linux__/{{ .Env.IMAGE_OS_CODENAME }}/latest"
       - "CRAN=https://p3m.dev/cran/__linux__/{{ .Env.IMAGE_OS_CODENAME }}/latest"
-  # Check for symlinked Quarto executable
+  # Quarto is bundled with Workbench.
+  /lib/rstudio-server/bin/quarto/bin/quarto:
+    exists: true
+    filetype: file
+    mode: "0755"
   /usr/local/bin/quarto:
     exists: true
     filetype: symlink
+    linked-to: /lib/rstudio-server/bin/quarto/bin/quarto
   # TinyTeX is installed under /opt/.TinyTeX (via HOME="/opt") so non-root runtime
   # users can read the install; tlmgr path add symlinks the binaries into
   # /usr/local/bin so they are on PATH.

--- a/workbench/2026.04/test/goss.yaml
+++ b/workbench/2026.04/test/goss.yaml
@@ -110,10 +110,15 @@ file:
     contents:
       - "RSPM=https://p3m.dev/cran/__linux__/{{ .Env.IMAGE_OS_CODENAME }}/latest"
       - "CRAN=https://p3m.dev/cran/__linux__/{{ .Env.IMAGE_OS_CODENAME }}/latest"
-  # Check for symlinked Quarto executable
+  # Quarto is bundled with Workbench.
+  /lib/rstudio-server/bin/quarto/bin/quarto:
+    exists: true
+    filetype: file
+    mode: "0755"
   /usr/local/bin/quarto:
     exists: true
     filetype: symlink
+    linked-to: /lib/rstudio-server/bin/quarto/bin/quarto
   # Check for R installation
 
   /opt/R/4.5.3/bin/R:

--- a/workbench/2026.05/test/goss.yaml
+++ b/workbench/2026.05/test/goss.yaml
@@ -110,10 +110,15 @@ file:
     contents:
       - "RSPM=https://p3m.dev/cran/__linux__/{{ .Env.IMAGE_OS_CODENAME }}/latest"
       - "CRAN=https://p3m.dev/cran/__linux__/{{ .Env.IMAGE_OS_CODENAME }}/latest"
-  # Check for symlinked Quarto executable
+  # Quarto is bundled with Workbench.
+  /lib/rstudio-server/bin/quarto/bin/quarto:
+    exists: true
+    filetype: file
+    mode: "0755"
   /usr/local/bin/quarto:
     exists: true
     filetype: symlink
+    linked-to: /lib/rstudio-server/bin/quarto/bin/quarto
   # TinyTeX is installed under /opt/.TinyTeX (via HOME="/opt") so non-root runtime
   # users can read the install; tlmgr path add symlinks the binaries into
   # /usr/local/bin so they are on PATH.

--- a/workbench/template/test/goss.yaml.jinja2
+++ b/workbench/template/test/goss.yaml.jinja2
@@ -122,10 +122,15 @@ file:
       - "RSPM=https://p3m.dev/cran/__linux__/{{ .Env.IMAGE_OS_CODENAME }}/latest"
       - "CRAN=https://p3m.dev/cran/__linux__/{{ .Env.IMAGE_OS_CODENAME }}/latest"
       {%- endraw %}
-  # Check for symlinked Quarto executable
+  # Quarto is bundled with Workbench.
+  /lib/rstudio-server/bin/quarto/bin/quarto:
+    exists: true
+    filetype: file
+    mode: "0755"
   /usr/local/bin/quarto:
     exists: true
     filetype: symlink
+    linked-to: /lib/rstudio-server/bin/quarto/bin/quarto
   # TinyTeX is installed under /opt/.TinyTeX (via HOME="/opt") so non-root runtime
   # users can read the install; tlmgr path add symlinks the binaries into
   # /usr/local/bin so they are on PATH.


### PR DESCRIPTION
The `/usr/local/bin/quarto` `file:` resource asserted only that the symlink exists with `filetype: symlink`, without verifying where it points. Promote the entry to assert `linked-to:` against the bundled path, and add an explicit entry for the real binary so both paths are covered structurally.

Quarto is bundled inside the Workbench install at `/lib/rstudio-server/bin/quarto/bin/quarto`. The Containerfile creates the `/usr/local/bin/quarto` symlink manually. If either path moves, the `linked-to:` assertion fails loudly at test time rather than later as a broken `quarto` invocation.