### PR TITLE
chore: remove temporary workbench images

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -88,4 +88,4 @@ jobs:
       dev-versions: "only"
       remove-dangling-caches: true
       remove-caches-older-than: 14
-      clean-temporary-images: false
+      remove-dangling-temporary-images: true

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -77,4 +77,4 @@ jobs:
     with:
       remove-dangling-caches: true
       remove-caches-older-than: 14
-      clean-temporary-images: false
+      remove-dangling-temporary-images: true

--- a/.github/workflows/session.yml
+++ b/.github/workflows/session.yml
@@ -75,5 +75,4 @@ jobs:
       matrix-versions: "only"
       remove-dangling-caches: true
       remove-caches-older-than: 14
-      remove-dangling-temporary-images: false
-      remove-temporary-images-older-than: 3
+      remove-dangling-temporary-images: true


### PR DESCRIPTION
Remove dangling images and images older than 3 days. This feature should have been enabled after switching to native builders.