### PR TITLE
Fix accidental reverts and out of sync definitions

### DIFF
--- a/workbench-session/matrix/Containerfile.ubuntu2204
+++ b/workbench-session/matrix/Containerfile.ubuntu2204
@@ -44,6 +44,14 @@ RUN apt-get update -yqq && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/*
 
+### Install Pro Drivers ###
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        rstudio-drivers && \
+    apt-get clean -yqq && \
+    rm -rf /var/lib/apt/lists/*
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
+
 # Install Python from previous stage
 COPY --from=python-builder /opt/python /opt/python
 

--- a/workbench-session/matrix/Containerfile.ubuntu2204
+++ b/workbench-session/matrix/Containerfile.ubuntu2204
@@ -21,6 +21,8 @@ ARG R_VERSION
 ARG PYTHON_VERSION
 ARG QUARTO_VERSION
 
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
 ### Install Apt Packages ###
 RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
     apt-get update -yqq --fix-missing && \

--- a/workbench-session/matrix/Containerfile.ubuntu2404
+++ b/workbench-session/matrix/Containerfile.ubuntu2404
@@ -21,6 +21,8 @@ ARG R_VERSION
 ARG PYTHON_VERSION
 ARG QUARTO_VERSION
 
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
 ### Install Apt Packages ###
 RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
     apt-get update -yqq --fix-missing && \

--- a/workbench-session/matrix/deps/ubuntu-22.04_packages.txt
+++ b/workbench-session/matrix/deps/ubuntu-22.04_packages.txt
@@ -7,6 +7,5 @@ libuser
 libuser1-dev
 libuv1-dev
 rrdtool
-rstudio-drivers
 subversion
 xz-utils

--- a/workbench-session/template/Containerfile.ubuntu2204.jinja2
+++ b/workbench-session/template/Containerfile.ubuntu2204.jinja2
@@ -21,6 +21,8 @@ ARG TARGETARCH=${BUILDARCH}
 {{ python.declare_build_arg() }}
 {{ quarto.declare_build_arg() }}
 
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
 ### Install Apt Packages ###
 {{ apt.run_setup() }}
 

--- a/workbench-session/template/Containerfile.ubuntu2204.jinja2
+++ b/workbench-session/template/Containerfile.ubuntu2204.jinja2
@@ -29,6 +29,10 @@ SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 COPY {{ Path.Version }}/deps/ubuntu-22.04_packages.txt /tmp/ubuntu-22.04_packages.txt
 {{ apt.run_install(files = '/tmp/ubuntu-22.04_packages.txt') }}
 
+### Install Pro Drivers ###
+{{ apt.run_install(packages="rstudio-drivers") }}
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
+
 # Install Python from previous stage
 {{ python.copy_from_build_stage() }}
 

--- a/workbench-session/template/Containerfile.ubuntu2404.jinja2
+++ b/workbench-session/template/Containerfile.ubuntu2404.jinja2
@@ -21,6 +21,8 @@ ARG TARGETARCH=${BUILDARCH}
 {{ python.declare_build_arg() }}
 {{ quarto.declare_build_arg() }}
 
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
 ### Install Apt Packages ###
 {{ apt.run_setup() }}
 

--- a/workbench-session/template/deps/ubuntu-22.04_packages.txt.jinja2
+++ b/workbench-session/template/deps/ubuntu-22.04_packages.txt.jinja2
@@ -7,6 +7,5 @@ libuser
 libuser1-dev
 libuv1-dev
 rrdtool
-rstudio-drivers
 subversion
 xz-utils

--- a/workbench/2025.09/Containerfile.ubuntu2204.std
+++ b/workbench/2025.09/Containerfile.ubuntu2204.std
@@ -105,7 +105,7 @@ COPY "workbench/2025.09/startup/base" /startup/base
 COPY "workbench/2025.09/startup/supervisord.conf" /etc/supervisor/supervisord.conf
 COPY "workbench/2025.09/startup/user-provisioning" /startup/user-provisioning
 COPY --chmod=600 "workbench/2025.09/conf/sssd/sssd.conf" /etc/sssd/sssd.conf
-COPY "workbench/2025.09/conf/jupyter/*" "workbench/2025.09/conf/launcher/*" "workbench/2025.09/conf/rstudio/*" "workbench/2025.09/conf/positron/*" "workbench/2025.09/conf/vscode/*" /etc/rstudio
+COPY "workbench/2025.09/conf/jupyter/*" "workbench/2025.09/conf/launcher/*" "workbench/2025.09/conf/rstudio/*" "workbench/2025.09/conf/positron/*" "workbench/2025.09/conf/vscode/*" /etc/rstudio/
 
 ### Configure Workbench ###
 RUN mkdir -p /var/lib/rstudio-server/monitor/log \

--- a/workbench/2025.09/Containerfile.ubuntu2204.std
+++ b/workbench/2025.09/Containerfile.ubuntu2204.std
@@ -94,9 +94,12 @@ RUN /opt/python/3.13.7/bin/pip install --no-cache-dir --upgrade --break-system-p
     /opt/python/3.13.7/bin/python -m ipykernel install --user --name python3.13.7 --display-name "Python 3.13.7"
 
 ### Install Pro Drivers ###
-RUN apt-get install -yq rstudio-drivers && \
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        rstudio-drivers && \
     apt-get clean -yqq && \
-rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Copy startup scripts ###
 COPY --chmod=0775 "workbench/2025.09/scripts/startup.sh" /usr/local/bin/startup.sh

--- a/workbench/2025.09/Containerfile.ubuntu2204.std
+++ b/workbench/2025.09/Containerfile.ubuntu2204.std
@@ -30,6 +30,8 @@ ENV PWB_DIAGNOSTIC_DIR=/var/log/rstudio
 ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
 
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
 ### Setup environment ###
 RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
     apt-get update -yqq --fix-missing && \

--- a/workbench/2025.09/Containerfile.ubuntu2204.std
+++ b/workbench/2025.09/Containerfile.ubuntu2204.std
@@ -129,7 +129,8 @@ RUN mkdir -p /var/lib/rstudio-server/monitor/log \
 # TODO: Remove `HOME="/opt"` once Quarto supports custom install locations
 # for TinyTeX, see https://github.com/quarto-dev/quarto-cli/issues/11800.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN HOME="/opt" /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --update-path \
+RUN --mount=type=secret,id=github_token,required=false \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --update-path \
     && rm -f /tmp/tinytex-release.json
 
 EXPOSE 8787/tcp

--- a/workbench/2025.09/Containerfile.ubuntu2404.std
+++ b/workbench/2025.09/Containerfile.ubuntu2404.std
@@ -79,7 +79,13 @@ COPY --from=python-builder /opt/python /opt/python
 ### Install Jupyter ###
 RUN /opt/python/3.13.7/bin/python -m venv /opt/python/jupyter && \
     /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    /opt/python/jupyter/bin/pip install --no-cache-dir 'jupyterlab<5' notebook 'pwb_jupyterlab<2' && \
+    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade \
+        "jupyterlab<5" \
+        notebook \
+        "pwb_jupyterlab<2" && \
+    rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests && \
+    rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/galata && \
+    rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \
     ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
 
 ### Install Jupyter kernels ###

--- a/workbench/2025.09/Containerfile.ubuntu2404.std
+++ b/workbench/2025.09/Containerfile.ubuntu2404.std
@@ -30,6 +30,8 @@ ENV PWB_DIAGNOSTIC_DIR=/var/log/rstudio
 ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
 
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
 ### Setup environment ###
 RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
     apt-get update -yqq --fix-missing && \

--- a/workbench/2025.09/Containerfile.ubuntu2404.std
+++ b/workbench/2025.09/Containerfile.ubuntu2404.std
@@ -129,7 +129,8 @@ RUN mkdir -p /var/lib/rstudio-server/monitor/log \
 # TODO: Remove `HOME="/opt"` once Quarto supports custom install locations
 # for TinyTeX, see https://github.com/quarto-dev/quarto-cli/issues/11800.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN HOME="/opt" /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --update-path \
+RUN --mount=type=secret,id=github_token,required=false \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --update-path \
     && rm -f /tmp/tinytex-release.json
 
 EXPOSE 8787/tcp

--- a/workbench/2025.09/Containerfile.ubuntu2404.std
+++ b/workbench/2025.09/Containerfile.ubuntu2404.std
@@ -100,7 +100,7 @@ COPY "workbench/2025.09/startup/base" /startup/base
 COPY "workbench/2025.09/startup/supervisord.conf" /etc/supervisor/supervisord.conf
 COPY "workbench/2025.09/startup/user-provisioning" /startup/user-provisioning
 COPY --chmod=600 "workbench/2025.09/conf/sssd/sssd.conf" /etc/sssd/sssd.conf
-COPY "workbench/2025.09/conf/jupyter/*" "workbench/2025.09/conf/launcher/*" "workbench/2025.09/conf/rstudio/*" "workbench/2025.09/conf/positron/*" "workbench/2025.09/conf/vscode/*" /etc/rstudio
+COPY "workbench/2025.09/conf/jupyter/*" "workbench/2025.09/conf/launcher/*" "workbench/2025.09/conf/rstudio/*" "workbench/2025.09/conf/positron/*" "workbench/2025.09/conf/vscode/*" /etc/rstudio/
 
 ### Configure Workbench ###
 RUN mkdir -p /var/lib/rstudio-server/monitor/log \

--- a/workbench/2025.09/Containerfile.ubuntu2404.std
+++ b/workbench/2025.09/Containerfile.ubuntu2404.std
@@ -58,8 +58,7 @@ RUN apt-get update -yqq && \
 
 
 ### Install wait-for-it ###
-RUN curl -fsSL -o /usr/local/bin/wait-for-it.sh https://raw.githubusercontent.com/rstudio/wait-for-it/master/wait-for-it.sh && \
-    chmod +x /usr/local/bin/wait-for-it.sh
+COPY --chmod=0755 workbench/scripts/wait-for-it.sh /usr/local/bin/wait-for-it.sh
 
 ### Install Workbench 2025.09.2+418.pro4 ###
 COPY --chmod=0755 workbench/2025.09/scripts/install_workbench.sh /tmp/install_workbench.sh

--- a/workbench/2025.09/Containerfile.ubuntu2404.std
+++ b/workbench/2025.09/Containerfile.ubuntu2404.std
@@ -89,9 +89,12 @@ RUN /opt/python/3.13.7/bin/pip install --no-cache-dir --upgrade --break-system-p
     /opt/python/3.13.7/bin/python -m ipykernel install --user --name python3.13.7 --display-name "Python 3.13.7"
 
 ### Install Pro Drivers ###
-RUN apt-get install -yq rstudio-drivers && \
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        rstudio-drivers && \
     apt-get clean -yqq && \
-rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Copy startup scripts ###
 COPY --chmod=0775 "workbench/2025.09/scripts/startup.sh" /usr/local/bin/startup.sh

--- a/workbench/2026.01/Containerfile.ubuntu2204.std
+++ b/workbench/2026.01/Containerfile.ubuntu2204.std
@@ -30,6 +30,8 @@ ENV PWB_DIAGNOSTIC_DIR=/var/log/rstudio
 ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
 
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
 ### Setup environment ###
 RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
     apt-get update -yqq --fix-missing && \

--- a/workbench/2026.01/Containerfile.ubuntu2204.std
+++ b/workbench/2026.01/Containerfile.ubuntu2204.std
@@ -129,7 +129,8 @@ RUN mkdir -p /var/lib/rstudio-server/monitor/log \
 # TODO: Remove `HOME="/opt"` once Quarto supports custom install locations
 # for TinyTeX, see https://github.com/quarto-dev/quarto-cli/issues/11800.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN HOME="/opt" /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --update-path \
+RUN --mount=type=secret,id=github_token,required=false \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --update-path \
     && rm -f /tmp/tinytex-release.json
 
 EXPOSE 8787/tcp

--- a/workbench/2026.01/Containerfile.ubuntu2204.std
+++ b/workbench/2026.01/Containerfile.ubuntu2204.std
@@ -105,7 +105,7 @@ COPY "workbench/2026.01/startup/base" /startup/base
 COPY "workbench/2026.01/startup/supervisord.conf" /etc/supervisor/supervisord.conf
 COPY "workbench/2026.01/startup/user-provisioning" /startup/user-provisioning
 COPY --chmod=600 "workbench/2026.01/conf/sssd/sssd.conf" /etc/sssd/sssd.conf
-COPY "workbench/2026.01/conf/jupyter/*" "workbench/2026.01/conf/launcher/*" "workbench/2026.01/conf/rstudio/*" "workbench/2026.01/conf/positron/*" "workbench/2026.01/conf/vscode/*" /etc/rstudio
+COPY "workbench/2026.01/conf/jupyter/*" "workbench/2026.01/conf/launcher/*" "workbench/2026.01/conf/rstudio/*" "workbench/2026.01/conf/positron/*" "workbench/2026.01/conf/vscode/*" /etc/rstudio/
 
 ### Configure Workbench ###
 RUN mkdir -p /var/lib/rstudio-server/monitor/log \

--- a/workbench/2026.01/Containerfile.ubuntu2204.std
+++ b/workbench/2026.01/Containerfile.ubuntu2204.std
@@ -94,9 +94,12 @@ RUN /opt/python/3.14.2/bin/pip install --no-cache-dir --upgrade --break-system-p
     /opt/python/3.14.2/bin/python -m ipykernel install --user --name python3.14.2 --display-name "Python 3.14.2"
 
 ### Install Pro Drivers ###
-RUN apt-get install -yq rstudio-drivers && \
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        rstudio-drivers && \
     apt-get clean -yqq && \
-rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Copy startup scripts ###
 COPY --chmod=0775 "workbench/2026.01/scripts/startup.sh" /usr/local/bin/startup.sh

--- a/workbench/2026.01/Containerfile.ubuntu2404.std
+++ b/workbench/2026.01/Containerfile.ubuntu2404.std
@@ -30,6 +30,8 @@ ENV PWB_DIAGNOSTIC_DIR=/var/log/rstudio
 ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
 
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
 ### Setup environment ###
 RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
     apt-get update -yqq --fix-missing && \

--- a/workbench/2026.01/Containerfile.ubuntu2404.std
+++ b/workbench/2026.01/Containerfile.ubuntu2404.std
@@ -129,7 +129,8 @@ RUN mkdir -p /var/lib/rstudio-server/monitor/log \
 # TODO: Remove `HOME="/opt"` once Quarto supports custom install locations
 # for TinyTeX, see https://github.com/quarto-dev/quarto-cli/issues/11800.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
-RUN HOME="/opt" /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --update-path \
+RUN --mount=type=secret,id=github_token,required=false \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --update-path \
     && rm -f /tmp/tinytex-release.json
 
 EXPOSE 8787/tcp

--- a/workbench/2026.01/Containerfile.ubuntu2404.std
+++ b/workbench/2026.01/Containerfile.ubuntu2404.std
@@ -105,7 +105,7 @@ COPY "workbench/2026.01/startup/base" /startup/base
 COPY "workbench/2026.01/startup/supervisord.conf" /etc/supervisor/supervisord.conf
 COPY "workbench/2026.01/startup/user-provisioning" /startup/user-provisioning
 COPY --chmod=600 "workbench/2026.01/conf/sssd/sssd.conf" /etc/sssd/sssd.conf
-COPY "workbench/2026.01/conf/jupyter/*" "workbench/2026.01/conf/launcher/*" "workbench/2026.01/conf/rstudio/*" "workbench/2026.01/conf/positron/*" "workbench/2026.01/conf/vscode/*" /etc/rstudio
+COPY "workbench/2026.01/conf/jupyter/*" "workbench/2026.01/conf/launcher/*" "workbench/2026.01/conf/rstudio/*" "workbench/2026.01/conf/positron/*" "workbench/2026.01/conf/vscode/*" /etc/rstudio/
 
 ### Configure Workbench ###
 RUN mkdir -p /var/lib/rstudio-server/monitor/log \

--- a/workbench/2026.01/Containerfile.ubuntu2404.std
+++ b/workbench/2026.01/Containerfile.ubuntu2404.std
@@ -94,9 +94,12 @@ RUN /opt/python/3.14.2/bin/pip install --no-cache-dir --upgrade --break-system-p
     /opt/python/3.14.2/bin/python -m ipykernel install --user --name python3.14.2 --display-name "Python 3.14.2"
 
 ### Install Pro Drivers ###
-RUN apt-get install -yq rstudio-drivers && \
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        rstudio-drivers && \
     apt-get clean -yqq && \
-rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Copy startup scripts ###
 COPY --chmod=0775 "workbench/2026.01/scripts/startup.sh" /usr/local/bin/startup.sh

--- a/workbench/2026.04/Containerfile.ubuntu2204.min
+++ b/workbench/2026.04/Containerfile.ubuntu2204.min
@@ -45,8 +45,7 @@ RUN apt-get update -yqq && \
     rm -rf /var/lib/apt/lists/*
 
 ### Install wait-for-it ###
-RUN curl -fsSL -o /usr/local/bin/wait-for-it.sh https://raw.githubusercontent.com/rstudio/wait-for-it/master/wait-for-it.sh && \
-    chmod +x /usr/local/bin/wait-for-it.sh
+COPY --chmod=0755 workbench/scripts/wait-for-it.sh /usr/local/bin/wait-for-it.sh
 
 ### Install Workbench 2026.04.0+526.pro2 ###
 COPY --chmod=0755 workbench/2026.04/scripts/install_workbench.sh /tmp/install_workbench.sh

--- a/workbench/2026.04/Containerfile.ubuntu2204.std
+++ b/workbench/2026.04/Containerfile.ubuntu2204.std
@@ -58,8 +58,7 @@ RUN apt-get update -yqq && \
 
 
 ### Install wait-for-it ###
-RUN curl -fsSL -o /usr/local/bin/wait-for-it.sh https://raw.githubusercontent.com/rstudio/wait-for-it/master/wait-for-it.sh && \
-    chmod +x /usr/local/bin/wait-for-it.sh
+COPY --chmod=0755 workbench/scripts/wait-for-it.sh /usr/local/bin/wait-for-it.sh
 
 ### Install Workbench 2026.04.0+526.pro2 ###
 COPY --chmod=0755 workbench/2026.04/scripts/install_workbench.sh /tmp/install_workbench.sh

--- a/workbench/2026.04/Containerfile.ubuntu2204.std
+++ b/workbench/2026.04/Containerfile.ubuntu2204.std
@@ -89,9 +89,12 @@ RUN /opt/python/3.14.4/bin/pip install --no-cache-dir --upgrade --break-system-p
     /opt/python/3.14.4/bin/python -m ipykernel install --user --name python3.14.4 --display-name "Python 3.14.4"
 
 ### Install Pro Drivers ###
-RUN apt-get install -yq rstudio-drivers && \
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        rstudio-drivers && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/*
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Copy startup scripts ###
 COPY --chmod=0775 "workbench/2026.04/scripts/startup.sh" /usr/local/bin/startup.sh

--- a/workbench/2026.04/Containerfile.ubuntu2204.std
+++ b/workbench/2026.04/Containerfile.ubuntu2204.std
@@ -79,7 +79,13 @@ COPY --from=python-builder /opt/python /opt/python
 ### Install Jupyter ###
 RUN /opt/python/3.14.4/bin/python -m venv /opt/python/jupyter && \
     /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    /opt/python/jupyter/bin/pip install --no-cache-dir 'jupyterlab<5' notebook 'pwb_jupyterlab<2' && \
+    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade \
+        "jupyterlab<5" \
+        notebook \
+        "pwb_jupyterlab<2" && \
+    rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests && \
+    rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/galata && \
+    rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \
     ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
 
 ### Install Jupyter kernels ###

--- a/workbench/2026.04/Containerfile.ubuntu2404.min
+++ b/workbench/2026.04/Containerfile.ubuntu2404.min
@@ -45,8 +45,7 @@ RUN apt-get update -yqq && \
     rm -rf /var/lib/apt/lists/*
 
 ### Install wait-for-it ###
-RUN curl -fsSL -o /usr/local/bin/wait-for-it.sh https://raw.githubusercontent.com/rstudio/wait-for-it/master/wait-for-it.sh && \
-    chmod +x /usr/local/bin/wait-for-it.sh
+COPY --chmod=0755 workbench/scripts/wait-for-it.sh /usr/local/bin/wait-for-it.sh
 
 ### Install Workbench 2026.04.0+526.pro2 ###
 COPY --chmod=0755 workbench/2026.04/scripts/install_workbench.sh /tmp/install_workbench.sh

--- a/workbench/2026.04/Containerfile.ubuntu2404.std
+++ b/workbench/2026.04/Containerfile.ubuntu2404.std
@@ -79,7 +79,13 @@ COPY --from=python-builder /opt/python /opt/python
 ### Install Jupyter ###
 RUN /opt/python/3.14.4/bin/python -m venv /opt/python/jupyter && \
     /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    /opt/python/jupyter/bin/pip install --no-cache-dir 'jupyterlab<5' notebook 'pwb_jupyterlab<2' && \
+    /opt/python/jupyter/bin/pip install --no-cache-dir --upgrade \
+        "jupyterlab<5" \
+        notebook \
+        "pwb_jupyterlab<2" && \
+    rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/tests && \
+    rm -rf /opt/python/jupyter/lib/python*/site-packages/jupyterlab/galata && \
+    rm -f /opt/python/jupyter/lib/python*/site-packages/jupyterlab/staging/yarn.lock && \
     ln -s /opt/python/jupyter/bin/jupyter /usr/local/bin/jupyter
 
 ### Install Jupyter kernels ###

--- a/workbench/2026.04/test/goss.yaml
+++ b/workbench/2026.04/test/goss.yaml
@@ -119,6 +119,18 @@ file:
     exists: true
     filetype: symlink
     linked-to: /lib/rstudio-server/bin/quarto/bin/quarto
+  # TinyTeX is installed under /opt/.TinyTeX (via HOME="/opt") so non-root runtime
+  # users can read the install; tlmgr path add symlinks the binaries into
+  # /usr/local/bin so they are on PATH.
+  /opt/.TinyTeX:
+    exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
+    filetype: directory
+  /usr/local/bin/tlmgr:
+    exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
+    filetype: symlink
+  /usr/local/bin/pdflatex:
+    exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
+    filetype: symlink
   # Check for R installation
 
   /opt/R/4.5.3/bin/R:
@@ -216,4 +228,16 @@ command:
     exit-status: 0
     stderr:
       - "/tinytex\\s+Up to date/"
+    skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}
+  "Verify TinyTeX is readable and executable by a non-root user":
+    # Runs tlmgr and pdflatex as `nobody` to confirm the /opt/.TinyTeX install
+    # is accessible to non-root. `command -v` also forces PATH resolution,
+    # not just direct invocation — proves the /usr/local/bin symlinks are on
+    # the user's PATH. Guards against regressions in placement, permissions,
+    # or PATH setup.
+    exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' nobody
+    exit-status: 0
+    stdout:
+      - "tlmgr"
+      - "pdfTeX"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}

--- a/workbench/2026.05/Containerfile.ubuntu2204.min
+++ b/workbench/2026.05/Containerfile.ubuntu2204.min
@@ -63,7 +63,7 @@ COPY --chmod=0775 "workbench/2026.05/scripts/startup.sh" /usr/local/bin/startup.
 COPY "workbench/2026.05/startup/launcher" /startup/launcher
 COPY "workbench/2026.05/startup/base" /startup/base
 COPY "workbench/2026.05/startup/supervisord.conf" /etc/supervisor/supervisord.conf
-COPY "workbench/2026.05/conf/jupyter/*" "workbench/2026.05/conf/launcher/*" "workbench/2026.05/conf/rstudio/*" "workbench/2026.05/conf/positron/*" "workbench/2026.05/conf/vscode/*" /etc/rstudio
+COPY "workbench/2026.05/conf/jupyter/*" "workbench/2026.05/conf/launcher/*" "workbench/2026.05/conf/rstudio/*" "workbench/2026.05/conf/positron/*" "workbench/2026.05/conf/vscode/*" /etc/rstudio/
 
 ### Configure Workbench ###
 RUN mkdir -p /var/lib/rstudio-server/monitor/log \

--- a/workbench/2026.05/Containerfile.ubuntu2204.min
+++ b/workbench/2026.05/Containerfile.ubuntu2204.min
@@ -20,6 +20,8 @@ ENV PWB_DIAGNOSTIC_DIR=/var/log/rstudio
 ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
 
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
 ### Setup environment ###
 RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
     apt-get update -yqq --fix-missing && \

--- a/workbench/2026.05/Containerfile.ubuntu2204.std
+++ b/workbench/2026.05/Containerfile.ubuntu2204.std
@@ -105,7 +105,7 @@ COPY "workbench/2026.05/startup/base" /startup/base
 COPY "workbench/2026.05/startup/supervisord.conf" /etc/supervisor/supervisord.conf
 COPY "workbench/2026.05/startup/user-provisioning" /startup/user-provisioning
 COPY --chmod=600 "workbench/2026.05/conf/sssd/sssd.conf" /etc/sssd/sssd.conf
-COPY "workbench/2026.05/conf/jupyter/*" "workbench/2026.05/conf/launcher/*" "workbench/2026.05/conf/rstudio/*" "workbench/2026.05/conf/positron/*" "workbench/2026.05/conf/vscode/*" /etc/rstudio
+COPY "workbench/2026.05/conf/jupyter/*" "workbench/2026.05/conf/launcher/*" "workbench/2026.05/conf/rstudio/*" "workbench/2026.05/conf/positron/*" "workbench/2026.05/conf/vscode/*" /etc/rstudio/
 
 ### Configure Workbench ###
 RUN mkdir -p /var/lib/rstudio-server/monitor/log \

--- a/workbench/2026.05/Containerfile.ubuntu2204.std
+++ b/workbench/2026.05/Containerfile.ubuntu2204.std
@@ -30,6 +30,8 @@ ENV PWB_DIAGNOSTIC_DIR=/var/log/rstudio
 ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
 
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
 ### Setup environment ###
 RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
     apt-get update -yqq --fix-missing && \

--- a/workbench/2026.05/Containerfile.ubuntu2204.std
+++ b/workbench/2026.05/Containerfile.ubuntu2204.std
@@ -94,9 +94,12 @@ RUN /opt/python/3.14.5/bin/pip install --no-cache-dir --upgrade --break-system-p
     /opt/python/3.14.5/bin/python -m ipykernel install --user --name python3.14.5 --display-name "Python 3.14.5"
 
 ### Install Pro Drivers ###
-RUN apt-get install -yq rstudio-drivers && \
+RUN apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+        rstudio-drivers && \
     apt-get clean -yqq && \
-rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/*
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Copy startup scripts ###
 COPY --chmod=0775 "workbench/2026.05/scripts/startup.sh" /usr/local/bin/startup.sh

--- a/workbench/2026.05/Containerfile.ubuntu2404.min
+++ b/workbench/2026.05/Containerfile.ubuntu2404.min
@@ -63,7 +63,7 @@ COPY --chmod=0775 "workbench/2026.05/scripts/startup.sh" /usr/local/bin/startup.
 COPY "workbench/2026.05/startup/launcher" /startup/launcher
 COPY "workbench/2026.05/startup/base" /startup/base
 COPY "workbench/2026.05/startup/supervisord.conf" /etc/supervisor/supervisord.conf
-COPY "workbench/2026.05/conf/jupyter/*" "workbench/2026.05/conf/launcher/*" "workbench/2026.05/conf/rstudio/*" "workbench/2026.05/conf/positron/*" "workbench/2026.05/conf/vscode/*" /etc/rstudio
+COPY "workbench/2026.05/conf/jupyter/*" "workbench/2026.05/conf/launcher/*" "workbench/2026.05/conf/rstudio/*" "workbench/2026.05/conf/positron/*" "workbench/2026.05/conf/vscode/*" /etc/rstudio/
 
 ### Configure Workbench ###
 RUN mkdir -p /var/lib/rstudio-server/monitor/log \

--- a/workbench/2026.05/Containerfile.ubuntu2404.min
+++ b/workbench/2026.05/Containerfile.ubuntu2404.min
@@ -20,6 +20,8 @@ ENV PWB_DIAGNOSTIC_DIR=/var/log/rstudio
 ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
 
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
 ### Setup environment ###
 RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
     apt-get update -yqq --fix-missing && \

--- a/workbench/2026.05/Containerfile.ubuntu2404.std
+++ b/workbench/2026.05/Containerfile.ubuntu2404.std
@@ -30,6 +30,8 @@ ENV PWB_DIAGNOSTIC_DIR=/var/log/rstudio
 ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
 
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
 ### Setup environment ###
 RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
     apt-get update -yqq --fix-missing && \

--- a/workbench/2026.05/Containerfile.ubuntu2404.std
+++ b/workbench/2026.05/Containerfile.ubuntu2404.std
@@ -108,7 +108,7 @@ COPY "workbench/2026.05/startup/base" /startup/base
 COPY "workbench/2026.05/startup/supervisord.conf" /etc/supervisor/supervisord.conf
 COPY "workbench/2026.05/startup/user-provisioning" /startup/user-provisioning
 COPY --chmod=600 "workbench/2026.05/conf/sssd/sssd.conf" /etc/sssd/sssd.conf
-COPY "workbench/2026.05/conf/jupyter/*" "workbench/2026.05/conf/launcher/*" "workbench/2026.05/conf/rstudio/*" "workbench/2026.05/conf/positron/*" "workbench/2026.05/conf/vscode/*" /etc/rstudio
+COPY "workbench/2026.05/conf/jupyter/*" "workbench/2026.05/conf/launcher/*" "workbench/2026.05/conf/rstudio/*" "workbench/2026.05/conf/positron/*" "workbench/2026.05/conf/vscode/*" /etc/rstudio/
 
 ### Configure Workbench ###
 RUN mkdir -p /var/lib/rstudio-server/monitor/log \

--- a/workbench/template/Containerfile.ubuntu2204.jinja2
+++ b/workbench/template/Containerfile.ubuntu2204.jinja2
@@ -79,8 +79,8 @@ RUN {{ python.install_packages(python_version, "ipykernel") }} && \
 {% endfor -%}
 
 ### Install Pro Drivers ###
-RUN apt-get install -yq rstudio-drivers && \
-    {{ apt.clean_command() }}
+{{ apt.run_install(packages="rstudio-drivers") }}
+RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 {%- endif %}
 
 ### Copy startup scripts ###

--- a/workbench/template/Containerfile.ubuntu2204.jinja2
+++ b/workbench/template/Containerfile.ubuntu2204.jinja2
@@ -92,7 +92,7 @@ COPY "{{ Path.Version }}/startup/supervisord.conf" /etc/supervisor/supervisord.c
 COPY "{{ Path.Version }}/startup/user-provisioning" /startup/user-provisioning
 COPY --chmod=600 "{{ Path.Version }}/conf/sssd/sssd.conf" /etc/sssd/sssd.conf
 {%- endif %}
-COPY "{{ Path.Version }}/conf/jupyter/*" "{{ Path.Version }}/conf/launcher/*" "{{ Path.Version }}/conf/rstudio/*" "{{ Path.Version }}/conf/positron/*" "{{ Path.Version }}/conf/vscode/*" /etc/rstudio
+COPY "{{ Path.Version }}/conf/jupyter/*" "{{ Path.Version }}/conf/launcher/*" "{{ Path.Version }}/conf/rstudio/*" "{{ Path.Version }}/conf/positron/*" "{{ Path.Version }}/conf/vscode/*" /etc/rstudio/
 
 ### Configure Workbench ###
 RUN mkdir -p /var/lib/rstudio-server/monitor/log \

--- a/workbench/template/Containerfile.ubuntu2204.jinja2
+++ b/workbench/template/Containerfile.ubuntu2204.jinja2
@@ -34,6 +34,8 @@ ENV PWB_DIAGNOSTIC_DIR=/var/log/rstudio
 ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
 
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
 ### Setup environment ###
 {{ apt.run_setup() }}
 

--- a/workbench/template/Containerfile.ubuntu2404.jinja2
+++ b/workbench/template/Containerfile.ubuntu2404.jinja2
@@ -92,7 +92,7 @@ COPY "{{ Path.Version }}/startup/supervisord.conf" /etc/supervisor/supervisord.c
 COPY "{{ Path.Version }}/startup/user-provisioning" /startup/user-provisioning
 COPY --chmod=600 "{{ Path.Version }}/conf/sssd/sssd.conf" /etc/sssd/sssd.conf
 {%- endif %}
-COPY "{{ Path.Version }}/conf/jupyter/*" "{{ Path.Version }}/conf/launcher/*" "{{ Path.Version }}/conf/rstudio/*" "{{ Path.Version }}/conf/positron/*" "{{ Path.Version }}/conf/vscode/*" /etc/rstudio
+COPY "{{ Path.Version }}/conf/jupyter/*" "{{ Path.Version }}/conf/launcher/*" "{{ Path.Version }}/conf/rstudio/*" "{{ Path.Version }}/conf/positron/*" "{{ Path.Version }}/conf/vscode/*" /etc/rstudio/
 
 ### Configure Workbench ###
 RUN mkdir -p /var/lib/rstudio-server/monitor/log \

--- a/workbench/template/Containerfile.ubuntu2404.jinja2
+++ b/workbench/template/Containerfile.ubuntu2404.jinja2
@@ -34,6 +34,8 @@ ENV PWB_DIAGNOSTIC_DIR=/var/log/rstudio
 ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
 
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
 ### Setup environment ###
 {{ apt.run_setup() }}
 


### PR DESCRIPTION
- Readd the `SHELL` declarations accidentally reverted by bc4ad7b6
- Readd trailing `/` for multifile `COPY` accidentally reverted by bc4ad7b6, fixes Hadolint DL3021 errors
- Synchronize `rstudio-drivers` install method in Ubuntu 22.04 images to match Ubuntu 24.04 (no functional changes)
- Use local wait-for-it.sh script as install source in definitions still targeting GitHub copy
- Synchronize Jupyter install macro in 2026.04 and 2025.09 to remove Jupyter paths detected vulnerable that go unused
- Readd missing GitHub token secret mounts for 2026.01 and 2025.09 to avoid ratelimiting in Quarto TinyTeX install
- Add missing TinyTeX install tests for Workbench 2026.04