### PR TITLE
Add which-image guide and update extending links

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,27 @@ podman build \
 
 To build images with `bakery` or run the test suite, see the [contributing guide](CONTRIBUTING.md).
 
+## Customizing images
+
+Each image serves a different role. The right image to customize depends on what you want to change.
+
+| I want to… | Customize | Example |
+|:-----------|:----------|:--------|
+| Add R or Python packages available in every user session | `workbench-session` | [session/r-python-packages](https://github.com/posit-dev/images-examples/tree/main/extending/workbench/session/r-python-packages) |
+| Add system libraries that session packages need | `workbench-session` | [session/system-dependencies](https://github.com/posit-dev/images-examples/tree/main/extending/workbench/session/system-dependencies) |
+| Change Workbench server configuration | `workbench` (Minimal) | [server/config](https://github.com/posit-dev/images-examples/tree/main/extending/workbench/server/config) |
+| Install additional languages on the Workbench server | `workbench` (Minimal) | [server/python](https://github.com/posit-dev/images-examples/tree/main/extending/workbench/server/python) |
+| Install Posit Pro Drivers on the Workbench server | `workbench` (Minimal) | [server/pro-drivers](https://github.com/posit-dev/images-examples/tree/main/extending/workbench/server/pro-drivers) |
+| Pre-install VS Code extensions | `workbench` (Standard) | [server/vs-code-extensions](https://github.com/posit-dev/images-examples/tree/main/extending/workbench/server/vs-code-extensions) |
+| Bundle session components into a self-contained session image | `workbench-session-init` + `workbench-session` | [session-init](https://github.com/posit-dev/images-examples/tree/main/extending/workbench/session-init) |
+| Run a newer Positron version than the Workbench server ships | `workbench-positron-init` | Helm `components.positron.version` |
+| Upgrade the Workbench server version | `workbench` + `workbench-session-init` (keep in sync) | — |
+
+For detailed guidance and full example code, see the [Workbench extending examples](https://github.com/posit-dev/images-examples/tree/main/extending/workbench).
+
 ## Related repositories
 
-This repository is part of the [Posit Container Images](https://github.com/posit-dev/images) ecosystem. To extend the Minimal image with additional languages or system dependencies, see the [extending examples](https://github.com/posit-dev/images-examples/tree/main/extending). For shared build tooling and CI workflows, see [images-shared](https://github.com/posit-dev/images-shared).
+This repository is part of the [Posit Container Images](https://github.com/posit-dev/images) ecosystem. For shared build tooling and CI workflows, see [images-shared](https://github.com/posit-dev/images-shared).
 
 ## Share your feedback
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ Each image serves a different role. The right image to customize depends on what
 
 | I want to… | Customize | Example |
 |:-----------|:----------|:--------|
-| Install specific versions of R or Python in sessions | `workbench-session` | [common/R](https://github.com/posit-dev/images-examples/tree/main/extending/common/R) · [common/python](https://github.com/posit-dev/images-examples/tree/main/extending/common/python) |
-| Add system libraries that session packages need | `workbench-session` | [common/system-dependencies](https://github.com/posit-dev/images-examples/tree/main/extending/common/system-dependencies) |
+| Add R or Python packages to sessions | `workbench-session` | [session/r-python-packages](https://github.com/posit-dev/images-examples/tree/main/extending/workbench/session/r-python-packages) |
+| Add system libraries that session packages need | `workbench-session` | [session/system-dependencies](https://github.com/posit-dev/images-examples/tree/main/extending/workbench/session/system-dependencies) |
 | Change Workbench server configuration | `workbench` (Minimal) | [server/config](https://github.com/posit-dev/images-examples/tree/main/extending/workbench/server/config) |
 | Install additional languages on the Workbench server | `workbench` (Minimal) | [common/R](https://github.com/posit-dev/images-examples/tree/main/extending/common/R) · [common/python](https://github.com/posit-dev/images-examples/tree/main/extending/common/python) |
 | Configure a Python package index | any | [Admin docs](https://docs.posit.co/ide/server-pro/admin/python/package_installation.html#setting-a-python-package-index-for-sessions) |

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ Each image serves a different role. The right image to customize depends on what
 | Add R or Python packages available in every user session | `workbench-session` | [session/r-python-packages](https://github.com/posit-dev/images-examples/tree/main/extending/workbench/session/r-python-packages) |
 | Add system libraries that session packages need | `workbench-session` | [session/system-dependencies](https://github.com/posit-dev/images-examples/tree/main/extending/workbench/session/system-dependencies) |
 | Change Workbench server configuration | `workbench` (Minimal) | [server/config](https://github.com/posit-dev/images-examples/tree/main/extending/workbench/server/config) |
-| Install additional languages on the Workbench server | `workbench` (Minimal) | [server/python](https://github.com/posit-dev/images-examples/tree/main/extending/workbench/server/python) |
+| Install additional languages on the Workbench server | `workbench` (Minimal) | [common/R](https://github.com/posit-dev/images-examples/tree/main/extending/common/R) · [common/python](https://github.com/posit-dev/images-examples/tree/main/extending/common/python) |
+| Configure a Python package index | any | [Admin docs](https://docs.posit.co/ide/server-pro/admin/python/package_installation.html#setting-a-python-package-index-for-sessions) |
 | Install Posit Pro Drivers on the Workbench server | `workbench` (Minimal) | [server/pro-drivers](https://github.com/posit-dev/images-examples/tree/main/extending/workbench/server/pro-drivers) |
 | Pre-install VS Code extensions | `workbench` (Standard) | [server/vs-code-extensions](https://github.com/posit-dev/images-examples/tree/main/extending/workbench/server/vs-code-extensions) |
 | Bundle session components into a self-contained session image | `workbench-session-init` + `workbench-session` | [session-init](https://github.com/posit-dev/images-examples/tree/main/extending/workbench/session-init) |

--- a/README.md
+++ b/README.md
@@ -39,11 +39,6 @@ Posit publishes additional container images to [Docker Hub](https://hub.docker.c
 
 The fastest way to get started is to pull and run a pre-built image. See each image's documentation for Quick Start examples, configuration, and environment variables.
 
-- [Workbench](./workbench/): the Workbench server
-- [Workbench Session](./workbench-session/): session images for Kubernetes
-- [Workbench Session Init](./workbench-session-init/): init container for Kubernetes session deployments
-- [Workbench Positron Init](./workbench-positron-init/): init container for Positron IDE in Kubernetes
-
 See the [Workbench installation guide](https://docs.posit.co/ide/server-pro/getting_started/installation/) for full setup instructions.
 
 ## Deploying on Kubernetes

--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ Container images for [Workbench](https://docs.posit.co/ide/server-pro).
 
 ## Images
 
-| Image | Docker Hub | GitHub Container Registry |
-|:------|:-----------|:--------------------------|
-| [workbench](./workbench/) | [`docker.io/posit/workbench`](https://hub.docker.com/r/posit/workbench) | [`ghcr.io/posit-dev/workbench`](https://github.com/posit-dev/images-workbench/pkgs/container/workbench) |
-| [workbench-session](./workbench-session/) | [`docker.io/posit/workbench-session`](https://hub.docker.com/r/posit/workbench-session) | [`ghcr.io/posit-dev/workbench-session`](https://github.com/posit-dev/images-workbench/pkgs/container/workbench-session) |
-| [workbench-session-init](./workbench-session-init/) | [`docker.io/posit/workbench-session-init`](https://hub.docker.com/r/posit/workbench-session-init) | [`ghcr.io/posit-dev/workbench-session-init`](https://github.com/posit-dev/images-workbench/pkgs/container/workbench-session-init) |
-| [workbench-positron-init](./workbench-positron-init/) | [`docker.io/posit/workbench-positron-init`](https://hub.docker.com/r/posit/workbench-positron-init) | [`ghcr.io/posit-dev/workbench-positron-init`](https://github.com/posit-dev/images-workbench/pkgs/container/workbench-positron-init) |
+| Image | Description | Docker Hub | GitHub Container Registry |
+|:------|:------------|:-----------|:--------------------------|
+| [workbench](./workbench/) | Provides the Workbench application.<br>This image is for all containerized deployments of Workbench. | [`docker.io/posit/workbench`](https://hub.docker.com/r/posit/workbench) | [`ghcr.io/posit-dev/workbench`](https://github.com/posit-dev/images-workbench/pkgs/container/workbench) |
+| [workbench-session](./workbench-session/) | Provides the session runtime environment for Workbench.<br>This image is used for Kubernetes deployments. | [`docker.io/posit/workbench-session`](https://hub.docker.com/r/posit/workbench-session) | [`ghcr.io/posit-dev/workbench-session`](https://github.com/posit-dev/images-workbench/pkgs/container/workbench-session) |
+| [workbench-session-init](./workbench-session-init/) | An init container for Workbench that pulls runtime components into a shared volume.<br>This image is for Kubernetes deployments. | [`docker.io/posit/workbench-session-init`](https://hub.docker.com/r/posit/workbench-session-init) | [`ghcr.io/posit-dev/workbench-session-init`](https://github.com/posit-dev/images-workbench/pkgs/container/workbench-session-init) |
+| [workbench-positron-init](./workbench-positron-init/) | An init container for Workbench that pulls Positron IDE components into a shared volume.<br>This optional image lets Kubernetes deployments upgrade Positron independently of Workbench releases. | [`docker.io/posit/workbench-positron-init`](https://hub.docker.com/r/posit/workbench-positron-init) | [`ghcr.io/posit-dev/workbench-positron-init`](https://github.com/posit-dev/images-workbench/pkgs/container/workbench-positron-init) |
 
 Posit publishes additional container images to [Docker Hub](https://hub.docker.com/u/posit) and [GitHub Container Registry](https://github.com/orgs/posit-dev/packages).
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ Each image serves a different role. The right image to customize depends on what
 
 | I want to… | Customize | Example |
 |:-----------|:----------|:--------|
-| Add R or Python packages available in every user session | `workbench-session` | [session/r-python-packages](https://github.com/posit-dev/images-examples/tree/main/extending/workbench/session/r-python-packages) |
-| Add system libraries that session packages need | `workbench-session` | [session/system-dependencies](https://github.com/posit-dev/images-examples/tree/main/extending/workbench/session/system-dependencies) |
+| Install specific versions of R or Python in sessions | `workbench-session` | [common/R](https://github.com/posit-dev/images-examples/tree/main/extending/common/R) · [common/python](https://github.com/posit-dev/images-examples/tree/main/extending/common/python) |
+| Add system libraries that session packages need | `workbench-session` | [common/system-dependencies](https://github.com/posit-dev/images-examples/tree/main/extending/common/system-dependencies) |
 | Change Workbench server configuration | `workbench` (Minimal) | [server/config](https://github.com/posit-dev/images-examples/tree/main/extending/workbench/server/config) |
 | Install additional languages on the Workbench server | `workbench` (Minimal) | [common/R](https://github.com/posit-dev/images-examples/tree/main/extending/common/R) · [common/python](https://github.com/posit-dev/images-examples/tree/main/extending/common/python) |
 | Configure a Python package index | any | [Admin docs](https://docs.posit.co/ide/server-pro/admin/python/package_installation.html#setting-a-python-package-index-for-sessions) |

--- a/workbench-positron-init/README.md
+++ b/workbench-positron-init/README.md
@@ -59,6 +59,8 @@ components:
       repository: "ghcr.io/posit-dev/workbench-positron-init"
 ```
 
+For a full guide to which Workbench image to customize for different goals, see the [Workbench extending examples](https://github.com/posit-dev/images-examples/tree/main/extending/workbench).
+
 ## Image tags
 
 Posit publishes images to:

--- a/workbench-positron-init/README.md
+++ b/workbench-positron-init/README.md
@@ -59,7 +59,7 @@ components:
       repository: "ghcr.io/posit-dev/workbench-positron-init"
 ```
 
-For a full guide to which Workbench image to customize for different goals, see the [Workbench extending examples](https://github.com/posit-dev/images-examples/tree/main/extending/workbench).
+For a guide to which Workbench image to customize for different goals, see the [Customizing images](https://github.com/posit-dev/images-workbench#customizing-images) section in the Workbench repository README.
 
 ## Image tags
 

--- a/workbench-session-init/README.md
+++ b/workbench-session-init/README.md
@@ -113,6 +113,8 @@ COPY --from=session-init /opt/session-components /opt/session-components
 
 The resulting image bundles the session components directly, so it can run Workbench sessions without an init container at runtime.
 
+See the [session-init extending example](https://github.com/posit-dev/images-examples/tree/main/extending/workbench/session-init) for a complete example of this pattern.
+
 ## Migrating from legacy image
 
 This image replaces the legacy [`rstudio/workbench-session-init`](https://hub.docker.com/r/rstudio/workbench-session-init) image. The runtime contents are unchanged. The image still ships the Workbench session components at `/opt/session-components` for a session container to consume. The differences are in how the image is published.

--- a/workbench-session/README.md
+++ b/workbench-session/README.md
@@ -102,7 +102,7 @@ FROM ghcr.io/posit-dev/workbench-session:R4.5.2-python3.14.3-ubuntu-24.04
 RUN /opt/R/4.5.2/bin/R -e 'install.packages("tidyverse", repos = "https://p3m.dev/cran/__linux__/noble/latest")'
 ```
 
-See [extending examples](https://github.com/posit-dev/images-examples/tree/main/extending) for additional patterns.
+See [session extending examples](https://github.com/posit-dev/images-examples/tree/main/extending/workbench/session) for additional patterns, including pre-installing Python packages and system dependencies.
 
 ## Migrating from legacy image
 

--- a/workbench/README.md
+++ b/workbench/README.md
@@ -114,7 +114,7 @@ Two variants are available:
 
 Each tagged image bundles a fixed set of dependencies. Both variants ship the `YYYY.MM` release of Workbench at the latest patch release available when the image was built. The `std` variant additionally ships one R version and one Python version, locked to the latest available at build time. The Containerfiles in this repository under `workbench/<version>/` document the exact versions in any tag. No arguments are overridden at build time.
 
-See [extending examples](https://github.com/posit-dev/images-examples/tree/main/extending) for how to build on the Minimal image.
+See [server extending examples](https://github.com/posit-dev/images-examples/tree/main/extending/workbench/server) for how to build on the Minimal image.
 
 ## Image tags
 


### PR DESCRIPTION
Adds a "Customizing images" section to the repo root README with a goal-to-image mapping table. Workbench has four images that serve distinct roles; it was not obvious which to customize for a given goal (the immediate motivation behind issue #112).

Updates the per-image extending-example links to point at the relevant `images-examples/extending/workbench/...` subfolder rather than the generic `extending/` root.

Closes https://github.com/posit-dev/images-workbench/issues/112

Depends on (must land first):

- https://github.com/posit-dev/images-examples/pull/36