### PR TITLE
Expand CONTRIBUTING.md with maintainer task guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,7 +193,7 @@ All workflows call shared reusable workflows from `images-shared`:
 | `session.yml` | `workbench-session` + `workbench-positron-init` matrix images | `bakery-build-native.yml` |
 
 Images push to `docker.io/posit` and `ghcr.io/posit-dev` on main merges and scheduled runs.
-Dev preview images push to AWS ECR.
+Dev preview images push to ghcr.io/posit-dev/workbench-preview.
 
 For CI failure diagnosis, see [CONTRIBUTING.md](CONTRIBUTING.md#diagnose-a-build-failure).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,7 +190,7 @@ All workflows call shared reusable workflows from `images-shared`:
 |---|---|---|
 | `production.yml` | `workbench` + `workbench-session-init` (excludes dev/matrix) | `bakery-build-native.yml` |
 | `development.yml` | Dev versions only (daily stream previews) | `bakery-build-native.yml` |
-| `session.yml` | `workbench-session` matrix images only | `bakery-build-native.yml` |
+| `session.yml` | `workbench-session` + `workbench-positron-init` matrix images | `bakery-build-native.yml` |
 
 Images push to `docker.io/posit` and `ghcr.io/posit-dev` on main merges and scheduled runs.
 Dev preview images push to AWS ECR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,11 +186,11 @@ When making changes to the repository, consider whether updates are required for
 
 All workflows call shared reusable workflows from `images-shared`:
 
-| Workflow | Schedule | What it builds | Shared workflow |
-|---|---|---|---|
-| `production.yml` | Weekly (Sun 03:15 UTC), PR, push to main | `workbench` + `workbench-session-init` (excludes dev/matrix) | `bakery-build-native.yml` |
-| `development.yml` | Daily (09:45 UTC), PR, push to main | Dev versions only (daily stream previews) | `bakery-build-native.yml` |
-| `session.yml` | Weekly (Sun 03:45 UTC), PR, push to main | `workbench-session` matrix images only | `bakery-build-native.yml` |
+| Workflow | What it builds | Shared workflow |
+|---|---|---|
+| `production.yml` | `workbench` + `workbench-session-init` (excludes dev/matrix) | `bakery-build-native.yml` |
+| `development.yml` | Dev versions only (daily stream previews) | `bakery-build-native.yml` |
+| `session.yml` | `workbench-session` matrix images only | `bakery-build-native.yml` |
 
 Images push to `docker.io/posit` and `ghcr.io/posit-dev` on main merges and scheduled runs.
 Dev preview images push to AWS ECR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,23 +188,14 @@ All workflows call shared reusable workflows from `images-shared`:
 
 | Workflow | Schedule | What it builds | Shared workflow |
 |---|---|---|---|
-| `production.yml` | Weekly (Sun 03:15 UTC), PR, push to main | `workbench` + `workbench-session-init` (excludes dev/matrix) | `bakery-build.yml` |
-| `development.yml` | Daily (04:45 UTC), PR, push to main | Dev versions only (daily stream previews) | `bakery-build.yml` |
-| `session.yml` | Weekly (Sun 04:15 UTC), PR, push to main | `workbench-session` matrix images only | `bakery-build.yml` |
+| `production.yml` | Weekly (Sun 03:15 UTC), PR, push to main | `workbench` + `workbench-session-init` (excludes dev/matrix) | `bakery-build-native.yml` |
+| `development.yml` | Daily (09:45 UTC), PR, push to main | Dev versions only (daily stream previews) | `bakery-build-native.yml` |
+| `session.yml` | Weekly (Sun 03:45 UTC), PR, push to main | `workbench-session` matrix images only | `bakery-build-native.yml` |
 
 Images push to `docker.io/posit` and `ghcr.io/posit-dev` on main merges and scheduled runs.
 Dev preview images push to AWS ECR.
 
-### CI failure checklist
-
-1. **Check which workflow failed** — production vs development vs session have different scopes
-2. **Read the failing step** — usually Build or Test
-3. **Common failures:**
-   - Python version not available in UV — a new Python minor version may not be in UV's release metadata yet
-   - Session-init download failure — S3 URL format uses `{{ Image.Version | replace('+', '-') }}`; verify the build artifact exists
-   - Goss test timeout — Workbench needs supervisor + launcher to start
-   - Registry auth — Docker Hub requires `DOCKER_HUB_ACCESS_TOKEN`, ECR requires AWS OIDC
-4. **Cache issues** — builds use `--cache-registry ghcr.io/posit-dev` for layer caching; stale caches can cause unexpected behavior
+For CI failure diagnosis, see [CONTRIBUTING.md](CONTRIBUTING.md#diagnose-a-build-failure).
 
 ## Helm Integration
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,10 +66,10 @@ covers the full workflow.
 
 Workbench versions are dispatched automatically from `rstudio/rstudio-pro` via the
 `workbench-ide-release` GitHub App, which triggers this repo's `release.yml` workflow.
-Manual steps are only needed for hotfixes.
+Use manual steps only for hotfixes.
 
 ```bash
-# Create a new version manually (e.g. a hotfix to 2026.01)
+# Create a new version manually (e.g., a hotfix to 2026.01)
 bakery create version 2026.01.2 --image-name workbench --image-name workbench-session-init
 bakery update files --image-name workbench --image-version 2026.01
 bakery update files --image-name workbench-session-init --image-version 2026.01
@@ -125,18 +125,11 @@ bakery run dgoss --image-name workbench --image-version 2026.01
 
 ### Footguns
 
-**`workbench-session-init` downloads from S3 during build.** The Containerfile fetches
-a binary whose URL embeds the image version with `+` replaced by `-` (via
-`{{ Image.Version | replace('+', '-') }}`). Verify the S3 artifact exists at the
-expected URL before creating a new version.
+- **`workbench-session-init` downloads from S3 during build.** The Containerfile fetches a binary whose URL embeds the image version with `+` replaced by `-` (via `{{ Image.Version | replace('+', '-') }}`). Verify the S3 artifact exists at the expected URL before creating a new version.
 
-**Workbench needs time to start.** The server, supervisor, and launcher all need to come
-up before goss can probe the container. Check the `wait:` value in the image's `options`
-block in `bakery.yaml` if goss probes fail immediately.
+- **Workbench needs time to start.** The server, supervisor, and launcher all need to come up before goss can probe the container. Check the `wait:` value in the image's `options` block in `bakery.yaml` if goss probes fail immediately.
 
-**`workbench-session` has no version directories.** It renders into
-`workbench-session/matrix/`. Do not create `workbench-session/<edition>/` directories
-manually.
+- **`workbench-session` has no version directories.** It renders into `workbench-session/matrix/`. Do not create `workbench-session/<edition>/` directories manually.
 
 → [Shared footguns](https://github.com/posit-dev/images-shared/blob/main/CONTRIBUTING.md#footguns)
 
@@ -152,11 +145,10 @@ All workflows use `bakery-build-native.yml` (native amd64 + arm64 runners).
 
 **Workbench-specific failures:**
 
-- _S3 download failure in `workbench-session-init`_ — the build fetches a binary from
+- S3 download failure in `workbench-session-init` — the build fetches a binary from
   S3. If the artifact does not exist for the dispatched version, the build fails at the
-  download step. Verify the product build artifact was published before the image build
-  was triggered.
-- _Goss timeout_ — Workbench needs supervisor and launcher to fully start before probes
+  download step. Verify the product team published the build artifact before the image build ran.
+- Goss timeout — Workbench needs supervisor and launcher to fully start before probes
   succeed. If goss fails immediately, check the `wait:` value in `bakery.yaml`.
 
 → [Shared failure scenarios](https://github.com/posit-dev/images-shared/blob/main/CONTRIBUTING.md#diagnose-a-build-failure)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,9 +138,6 @@ block in `bakery.yaml` if goss probes fail immediately.
 `workbench-session/matrix/`. Do not create `workbench-session/<edition>/` directories
 manually.
 
-**Dev images push to AWS ECR.** The `development.yml` workflow requires `id-token: write`
-and `AWS_ROLE` for ECR auth.
-
 → [Shared footguns](https://github.com/posit-dev/images-shared/blob/main/CONTRIBUTING.md#footguns)
 
 ### Diagnose a build failure
@@ -148,7 +145,7 @@ and `AWS_ROLE` for ECR auth.
 | Workflow | Schedule | Builds |
 |---|---|---|
 | `production.yml` | Weekly Sun 03:15 UTC, push to main, dispatch | `workbench` + `workbench-session-init` (excludes dev and matrix) |
-| `development.yml` | Daily 09:45 UTC, push to main, dispatch | Dev stream previews → AWS ECR |
+| `development.yml` | Daily 09:45 UTC, push to main, dispatch | Dev stream previews → ghcr.io/posit-dev/workbench-preview |
 | `session.yml` | Weekly Sun 03:45 UTC, push to main, dispatch | `workbench-session` + `workbench-positron-init` matrix images |
 
 All workflows use `bakery-build-native.yml` (native amd64 + arm64 runners).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,63 +1,164 @@
 # Contributing to Posit Workbench container images
 
-This guide covers how to build and test the Workbench container images with the `bakery` CLI. To build images directly with Docker, Buildah, or Podman, see the [README](README.md#build). To deploy or run pre-built images, see the [running the images](README.md#running-the-images) section.
+This guide covers how to build and test the Workbench container images locally, and how
+to perform common maintenance tasks. To build images directly with Docker, Buildah, or
+Podman, see the [README](README.md#build). To deploy or run pre-built images, see the
+[README](README.md#running-the-images).
 
-## Using `bakery`
-
-This repository follows the structure described in [bakery usage](https://github.com/posit-dev/images-shared/tree/main/posit-bakery#usage).
-
-Additional documentation:
-- [Configuration reference](https://github.com/posit-dev/images-shared/blob/main/posit-bakery/CONFIGURATION.md): `bakery.yaml` schema and options
-- [Templating reference](https://github.com/posit-dev/images-shared/blob/main/posit-bakery/TEMPLATING.md): Jinja2 macros for Containerfile templates
-- [CI workflows](https://github.com/posit-dev/images-shared/blob/main/CI.md): Shared GitHub Actions workflows for building and pushing images
-
-The [`bakery.yaml`](https://github.com/posit-dev/images-shared/blob/main/posit-bakery/CONFIGURATION.md#bakery-configuration) file, or project, is in the root of this repository.
+## Build and test
 
 ### Prerequisites
 
-Build prerequisites:
-
-* [python](https://docs.astral.sh/uv/guides/install-python/)
-* [uv](https://docs.astral.sh/uv/getting-started/installation/)
-* [docker buildx bake](https://github.com/docker/buildx#installing)
-* [just](https://just.systems/man/en/prerequisites.html)
-* [gh](https://github.com/cli/cli#installation) (required while repositories are private)
-* `bakery`
-
-    ```shell
-    just install-bakery
-    ```
-
-* `goss` and `dgoss` for running image validation tests
-
-    ```shell
-    just install-goss
-    ```
-
-* [`pre-commit`](https://pre-commit.com/) hooks (for contributors)
-
-    ```shell
-    just setup
-    ```
-
-### Build with `bakery`
-
-By default, bakery creates an ephemeral JSON [bakefile](https://docs.bakefile.org/en/latest/language.html) to render all containers in parallel.
+| Tool | Install |
+|---|---|
+| [python](https://docs.astral.sh/uv/guides/install-python/) + [uv](https://docs.astral.sh/uv/getting-started/installation/) | Required for `bakery` |
+| [docker buildx bake](https://github.com/docker/buildx#installing) | Required for builds |
+| [just](https://just.systems/man/en/prerequisites.html) | Task runner |
+| [gh](https://github.com/cli/cli#installation) | Required while repositories are private |
 
 ```shell
+# Install bakery and goss
+just init
+
+# Install pre-commit hooks
+just setup
+```
+
+### Build
+
+```shell
+# Preview the build plan
+bakery build --plan
+
+# Build all images
 bakery build
+
+# Build a specific image and version
+bakery build --image-name workbench --image-version 2026.01
 ```
 
-You can view the bake plan using `bakery build --plan`.
-
-You can use CLI flags to build only a subset of images in the project.
-
-### Test images
-
-After building the container images, run the test suite for all images:
+### Test
 
 ```shell
+# Run goss tests for all images
 bakery run dgoss
+
+# Run goss tests for a specific image
+bakery run dgoss --image-name workbench
 ```
 
-You can use CLI flags to limit the tests to run against a subset of images.
+### Re-render templates
+
+After changing any file in a `template/` directory, re-render the version directories:
+
+```shell
+bakery update files
+bakery update files --image-name workbench --image-version 2026.01
+```
+
+## Maintainer tasks
+
+Each section below has Workbench-specific context and a concrete example. The linked
+procedure in the [shared maintainer guide](https://github.com/posit-dev/images-shared/blob/main/CONTRIBUTING.md)
+covers the full workflow.
+
+### Add a version
+
+Workbench versions are dispatched automatically from `rstudio/rstudio-pro` via the
+`workbench-ide-release` GitHub App, which triggers this repo's `release.yml` workflow.
+Manual steps are only needed for hotfixes.
+
+```bash
+# Create a new version manually (e.g. a hotfix to 2026.01)
+bakery create version 2026.01.2 --image-name workbench --image-name workbench-session-init
+bakery update files --image-name workbench --image-version 2026.01
+bakery update files --image-name workbench-session-init --image-version 2026.01
+```
+
+`workbench-session` is a matrix image. Its versions are managed via `matrixVersions` in
+`bakery.yaml`, not with `bakery create version`.
+
+→ [Shared procedure](https://github.com/posit-dev/images-shared/blob/main/CONTRIBUTING.md#add-a-version)
+
+### Add an image
+
+This repo has four images: `workbench` (server), `workbench-session` (R×Python matrix),
+`workbench-session-init`, and `workbench-positron-init`. Adding a new image requires
+coordination with the Workbench product team.
+
+```bash
+# Scaffold a new image directory and template
+bakery create image <new-image-name>
+```
+
+→ [Shared procedure](https://github.com/posit-dev/images-shared/blob/main/CONTRIBUTING.md#add-an-image)
+
+### Update dependencies
+
+`workbench-session` is a matrix image with R×Python combinations defined in `bakery.yaml`
+under `matrixVersions`. To add a new R or Python version to the session matrix, add it
+to `matrixVersions` and re-render:
+
+```bash
+bakery update files --image-name workbench-session
+```
+
+`workbench` and `workbench-session-init` use `dependencyConstraints` for their
+non-matrix dependencies.
+
+→ [Shared procedure](https://github.com/posit-dev/images-shared/blob/main/CONTRIBUTING.md#update-dependencies)
+
+### Update older versions
+
+```bash
+# Edit the template, then re-render a specific edition
+bakery update files --image-name workbench --image-version 2026.01
+bakery update files --image-name workbench-session-init --image-version 2026.01
+
+# Build and test before opening a PR
+bakery build --image-name workbench --image-version 2026.01
+bakery run dgoss --image-name workbench --image-version 2026.01
+```
+
+→ [Shared procedure](https://github.com/posit-dev/images-shared/blob/main/CONTRIBUTING.md#update-older-versions)
+
+### Footguns
+
+**`workbench-session-init` downloads from S3 during build.** The Containerfile fetches
+a binary whose URL embeds the image version with `+` replaced by `-` (via
+`{{ Image.Version | replace('+', '-') }}`). Verify the S3 artifact exists at the
+expected URL before creating a new version.
+
+**Workbench needs time to start.** The server, supervisor, and launcher all need to come
+up before goss can probe the container. Check the `wait:` value in the image's `options`
+block in `bakery.yaml` if goss probes fail immediately.
+
+**`workbench-session` has no version directories.** It renders into
+`workbench-session/matrix/`. Do not create `workbench-session/<edition>/` directories
+manually.
+
+**Dev images push to AWS ECR.** The `development.yml` workflow requires `id-token: write`
+and `AWS_ROLE` for ECR auth.
+
+→ [Shared footguns](https://github.com/posit-dev/images-shared/blob/main/CONTRIBUTING.md#footguns)
+
+### Diagnose a build failure
+
+| Workflow | Schedule | Builds |
+|---|---|---|
+| `production.yml` | Weekly Sun 03:15 UTC, push to main, dispatch | `workbench` + `workbench-session-init` (excludes dev and matrix) |
+| `development.yml` | Daily 09:45 UTC, push to main, dispatch | Dev stream previews → AWS ECR |
+| `session.yml` | Weekly Sun 03:45 UTC, push to main, dispatch | `workbench-session` matrix images only |
+
+All workflows use `bakery-build-native.yml` (native amd64 + arm64 runners).
+
+**Workbench-specific failures:**
+
+- _S3 download failure in `workbench-session-init`_ — the build fetches a binary from
+  S3. If the artifact does not exist for the dispatched version, the build fails at the
+  download step. Verify the product build artifact was published before the image build
+  was triggered.
+- _Goss timeout_ — Workbench needs supervisor and launcher to fully start before probes
+  succeed. If goss fails immediately, check the `wait:` value in `bakery.yaml`.
+
+→ [Shared failure scenarios](https://github.com/posit-dev/images-shared/blob/main/CONTRIBUTING.md#diagnose-a-build-failure)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,8 @@ bakery run dgoss --image-name workbench
 After changing any file in a `template/` directory, re-render the version directories:
 
 ```shell
-bakery update files
+# Omitting filters re-renders every image and version; --help shows available filters
+bakery update files --help
 bakery update files --image-name workbench --image-version 2026.01
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,8 +75,8 @@ bakery update files --image-name workbench --image-version 2026.01
 bakery update files --image-name workbench-session-init --image-version 2026.01
 ```
 
-`workbench-session` is a matrix image. Its versions are managed via `matrixVersions` in
-`bakery.yaml`, not with `bakery create version`.
+`workbench-session` is a matrix image. Its versions are managed via
+`matrix.dependencyConstraints` in `bakery.yaml`, not with `bakery create version`.
 
 → [Shared procedure](https://github.com/posit-dev/images-shared/blob/main/CONTRIBUTING.md#add-a-version)
 
@@ -96,8 +96,9 @@ bakery create image <new-image-name>
 ### Update dependencies
 
 `workbench-session` is a matrix image with R×Python combinations defined in `bakery.yaml`
-under `matrixVersions`. To add a new R or Python version to the session matrix, add it
-to `matrixVersions` and re-render:
+under `matrix.dependencyConstraints`. To add a new R or Python version to the session
+matrix, update the image's `matrix.dependencyConstraints` block in `bakery.yaml` and
+re-render:
 
 ```bash
 bakery update files --image-name workbench-session
@@ -148,7 +149,7 @@ and `AWS_ROLE` for ECR auth.
 |---|---|---|
 | `production.yml` | Weekly Sun 03:15 UTC, push to main, dispatch | `workbench` + `workbench-session-init` (excludes dev and matrix) |
 | `development.yml` | Daily 09:45 UTC, push to main, dispatch | Dev stream previews → AWS ECR |
-| `session.yml` | Weekly Sun 03:45 UTC, push to main, dispatch | `workbench-session` matrix images only |
+| `session.yml` | Weekly Sun 03:45 UTC, push to main, dispatch | `workbench-session` + `workbench-positron-init` matrix images |
 
 All workflows use `bakery-build-native.yml` (native amd64 + arm64 runners).
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ podman build \
 ## Contributing
 
 To build images with `bakery` or run the test suite, see the [contributing guide](CONTRIBUTING.md).
+For image maintainers, the contributing guide also covers adding versions, updating
+dependencies, backporting to older versions, known footguns, and CI failure diagnosis.
 
 ## Related repositories
 


### PR DESCRIPTION
The existing CONTRIBUTING.md covered only local build and test. A new maintainer had no documented path for the six most common operations: adding a version, adding an image, updating dependencies, backporting to older versions, avoiding footguns, and diagnosing CI failures.

This rewrites CONTRIBUTING.md with a maintainer task guide. Each section has Workbench-specific context and a concrete example inline, then links to the shared procedure in images-shared for depth.

Also:
- Removes the CI failure checklist from CLAUDE.md — content now lives in CONTRIBUTING.md
- Removes the schedule column from the CLAUDE.md CI workflow table (schedules are the authoritative version in CONTRIBUTING.md, eliminating the drift that caused stale values)
- Corrects pre-existing inaccuracies in the CI workflow table (wrong shared workflow name `bakery-build.yml` → `bakery-build-native.yml`, wrong schedule times, `session.yml` scope now includes `workbench-positron-init`)
- Fixes a pre-existing error in CLAUDE.md: dev images push to `ghcr.io/posit-dev/workbench-preview`, not AWS ECR

Part of a coordinated change across four repos:
- https://github.com/posit-dev/images-shared/pull/564
- https://github.com/posit-dev/images-connect/pull/118
- https://github.com/posit-dev/images-package-manager/pull/102