### PR TITLE
Document why init images target Ubuntu 24.04 only

### DIFF
--- a/bakery.yaml
+++ b/bakery.yaml
@@ -122,6 +122,7 @@ images:
       - sourceType: stream
         product: workbench-session
         stream: daily
+        # Runtime binary is arch-specific, not OS-specific; Ubuntu 24.04 only.
         os:
           - name: Ubuntu 24.04
             primary: true
@@ -166,6 +167,7 @@ images:
           constraint:
             latest: true
             count: 6
+      # Runtime binary is arch-specific, not OS-specific; Ubuntu 24.04 only.
       os:
         - name: Ubuntu 24.04
           primary: true


### PR DESCRIPTION
The `workbench-session-init` and `workbench-positron-init` images copy an
architecture-specific runtime binary. The OS variant has no effect on what
gets downloaded, so Ubuntu 24.04 is the only target. Add a comment at the
`os:` key in each image to make this explicit.