### PR TITLE
Add workbench-positron-init daily preview stream

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -69,8 +69,9 @@ jobs:
       contents: read
       packages: write
 
-    uses: "posit-dev/images-shared/.github/workflows/bakery-build-native.yml@main"
+    uses: "posit-dev/images-shared/.github/workflows/bakery-build-native.yml@positron-init-preview-stream"
     with:
+      version: "positron-init-preview-stream"
       dev-versions: "only"
       matrix-versions: "exclude"
       image-version: ${{ inputs.version }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,8 +47,9 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
+    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@positron-init-preview-stream
     with:
+      version: "positron-init-preview-stream"
       dev-versions: "exclude"
       matrix-versions: "exclude"
 
@@ -57,8 +58,9 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
+    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@positron-init-preview-stream
     with:
+      version: "positron-init-preview-stream"
       dev-versions: "only"
       matrix-versions: "exclude"
 
@@ -67,8 +69,9 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
+    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@positron-init-preview-stream
     with:
+      version: "positron-init-preview-stream"
       matrix-versions: "only"
 
   zizmor:

--- a/bakery.yaml
+++ b/bakery.yaml
@@ -173,6 +173,7 @@ images:
       - sourceType: dependency
         dependency: positron
         prerelease: true
+        channel: daily
         values:
           POSITRON_CHANNEL: dailies
         os:

--- a/bakery.yaml
+++ b/bakery.yaml
@@ -169,6 +169,22 @@ images:
     options:
       - tool: soci
         enabled: true
+    devVersions:
+      - sourceType: dependency
+        dependency: positron
+        prerelease: true
+        values:
+          POSITRON_CHANNEL: dailies
+        os:
+          - name: Ubuntu 24.04
+            primary: true
+            platforms:
+              - linux/amd64
+              - linux/arm64
+        overrideRegistries:
+          - host: "ghcr.io"
+            namespace: "posit-dev"
+            repository: "workbench-positron-init-preview"
     matrix:
       namePattern: "{{ Dependencies.positron }}"
       dependencyConstraints:

--- a/bakery.yaml
+++ b/bakery.yaml
@@ -127,7 +127,7 @@ images:
     devVersions:
       - sourceType: stream
         product: workbench-session
-        stream: daily
+        channel: daily
         # Runtime binary is arch-specific, not OS-specific; Ubuntu 24.04 only.
         os:
           - name: Ubuntu 24.04

--- a/workbench-positron-init/matrix/Containerfile.ubuntu2404
+++ b/workbench-positron-init/matrix/Containerfile.ubuntu2404
@@ -5,10 +5,6 @@ ARG BUILDARCH
 ARG TARGETARCH=${BUILDARCH}
 ARG POSITRON_VERSION
 
-ENV PWB_POSITRON_TARGET="positron,positron-docs"
-
-SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
-
 RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
     apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
@@ -37,20 +33,19 @@ RUN case ${TARGETARCH} in \
       arm64) CDN_ARCH=arm64;  PKG_ARCH=arm64; INIT_ARTIFACT=linux-arm64 ;; \
       *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
     esac && \
-    # Download positron-server tarball from CDN
     mkdir -p /opt/positron/bin/positron-server && \
     curl -fsSL -o /tmp/positron.tar.gz \
+\
       "https://cdn.posit.co/positron/releases/pwb/${CDN_ARCH}/positron-workbench-linux-${PKG_ARCH}-${POSITRON_VERSION}.tar.gz" && \
+\
     tar -xzf /tmp/positron.tar.gz -C /tmp && \
     mv /tmp/vscode-reh-web-*linux-* /opt/positron/bin/positron-server/bundled && \
     rm /tmp/positron.tar.gz && \
-    # Download positron docs from CDN
     mkdir -p /opt/positron/docs/positron && \
     curl -fsSL -o /tmp/docs.zip \
       "https://cdn.posit.co/positron/releases/docs/positron-workbench-docs-${POSITRON_VERSION}.zip" && \
     unzip -qo /tmp/docs.zip -d /opt/positron/docs/positron && \
     rm /tmp/docs.zip && \
-    # Download latest positron-session-init binary from CDN
     BINARY_URL=$(curl -fsSL "https://cdn.posit.co/pwb-components/positron-session-init/latest.json" \
       | jq -r ".artifacts[\"${INIT_ARTIFACT}\"].url") && \
     curl -fsSL -o /tmp/positron-session-init.tar.gz "$BINARY_URL" && \
@@ -64,13 +59,16 @@ LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
-    apt-get update -yqq --fix-missing && \
+RUN apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/*
+
+
+ENV PWB_POSITRON_TARGET="positron,positron-docs"
+
 
 COPY --from=builder --chmod=755 /usr/local/bin/positron-session-init /usr/local/bin/positron-session-init
 COPY --from=builder --chmod=755 /opt/positron /opt/positron

--- a/workbench-positron-init/matrix/Containerfile.ubuntu2404
+++ b/workbench-positron-init/matrix/Containerfile.ubuntu2404
@@ -5,6 +5,8 @@ ARG BUILDARCH
 ARG TARGETARCH=${BUILDARCH}
 ARG POSITRON_VERSION
 
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
 RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
     apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \

--- a/workbench-positron-init/matrix/Containerfile.ubuntu2404
+++ b/workbench-positron-init/matrix/Containerfile.ubuntu2404
@@ -44,10 +44,12 @@ RUN case ${TARGETARCH} in \
     mv /tmp/vscode-reh-web-*linux-* /opt/positron/bin/positron-server/bundled && \
     rm /tmp/positron.tar.gz && \
     mkdir -p /opt/positron/docs/positron && \
+\
     curl -fsSL -o /tmp/docs.zip \
       "https://cdn.posit.co/positron/releases/docs/positron-workbench-docs-${POSITRON_VERSION}.zip" && \
     unzip -qo /tmp/docs.zip -d /opt/positron/docs/positron && \
     rm /tmp/docs.zip && \
+\
     BINARY_URL=$(curl -fsSL "https://cdn.posit.co/pwb-components/positron-session-init/latest.json" \
       | jq -r ".artifacts[\"${INIT_ARTIFACT}\"].url") && \
     curl -fsSL -o /tmp/positron-session-init.tar.gz "$BINARY_URL" && \
@@ -61,16 +63,15 @@ LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update -yqq --fix-missing && \
+RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
+    apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/*
 
-
 ENV PWB_POSITRON_TARGET="positron,positron-docs"
-
 
 COPY --from=builder --chmod=755 /usr/local/bin/positron-session-init /usr/local/bin/positron-session-init
 COPY --from=builder --chmod=755 /opt/positron /opt/positron

--- a/workbench-positron-init/template/Containerfile.ubuntu2404.jinja2
+++ b/workbench-positron-init/template/Containerfile.ubuntu2404.jinja2
@@ -38,12 +38,19 @@ RUN case ${TARGETARCH} in \
 {% endif %}\
     tar -xzf /tmp/positron.tar.gz -C /tmp && \
     mv /tmp/vscode-reh-web-*linux-* /opt/positron/bin/positron-server/bundled && \
-    rm /tmp/positron.tar.gz{% if not is_dev %} && \
+    rm /tmp/positron.tar.gz && \
     mkdir -p /opt/positron/docs/positron && \
+{% if is_dev %}\
+    { curl -fsSL -o /tmp/docs.zip \
+        "https://cdn.posit.co/positron/dailies/docs/positron-workbench-docs-{{ Image.Version }}.zip" && \
+      unzip -qo /tmp/docs.zip -d /opt/positron/docs/positron; } || true && \
+    rm -f /tmp/docs.zip && \
+{% else %}\
     curl -fsSL -o /tmp/docs.zip \
       "https://cdn.posit.co/positron/releases/docs/positron-workbench-docs-${POSITRON_VERSION}.zip" && \
     unzip -qo /tmp/docs.zip -d /opt/positron/docs/positron && \
-    rm /tmp/docs.zip{% endif %} && \
+    rm /tmp/docs.zip && \
+{% endif %}\
     BINARY_URL=$(curl -fsSL "https://cdn.posit.co/pwb-components/positron-session-init/latest.json" \
       | jq -r ".artifacts[\"${INIT_ARTIFACT}\"].url") && \
     curl -fsSL -o /tmp/positron-session-init.tar.gz "$BINARY_URL" && \
@@ -57,13 +64,10 @@ LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-{{ apt.run_update_upgrade() }}
+RUN {{ apt.configure_retries() }} && \
+    {{ apt.update_upgrade() | indent(4) }}
 
-{% if is_dev %}
-ENV PWB_POSITRON_TARGET="positron"
-{% else %}
 ENV PWB_POSITRON_TARGET="positron,positron-docs"
-{% endif %}
 
 COPY --from=builder --chmod=755 /usr/local/bin/positron-session-init /usr/local/bin/positron-session-init
 COPY --from=builder --chmod=755 /opt/positron /opt/positron

--- a/workbench-positron-init/template/Containerfile.ubuntu2404.jinja2
+++ b/workbench-positron-init/template/Containerfile.ubuntu2404.jinja2
@@ -3,16 +3,13 @@ Below are imports for Bakery's macros. If any are unneeded, they can be removed.
 Bakery handles bootstrapping the files into template rendering.
 -#}
 {%- import "apt.j2" as apt -%}
+{%- set is_dev = Image.IsDevelopmentVersion is defined and Image.IsDevelopmentVersion -%}
 FROM docker.io/library/ubuntu:24.04 AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG BUILDARCH
 ARG TARGETARCH=${BUILDARCH}
-ARG POSITRON_VERSION
-
-ENV PWB_POSITRON_TARGET="positron,positron-docs"
-
-SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+{% if not is_dev %}ARG POSITRON_VERSION{% endif %}
 
 {{ apt.run_setup() }}
 
@@ -30,20 +27,21 @@ RUN case ${TARGETARCH} in \
       arm64) CDN_ARCH=arm64;  PKG_ARCH=arm64; INIT_ARTIFACT=linux-arm64 ;; \
       *) echo "Unsupported architecture: ${TARGETARCH}" && exit 1 ;; \
     esac && \
-    # Download positron-server tarball from CDN
     mkdir -p /opt/positron/bin/positron-server && \
     curl -fsSL -o /tmp/positron.tar.gz \
+{% if is_dev %}\
+      "https://cdn.posit.co/positron/dailies/pwb/${CDN_ARCH}/positron-workbench-linux-${PKG_ARCH}-{{ Image.Version }}.tar.gz" && \
+{% else %}\
       "https://cdn.posit.co/positron/releases/pwb/${CDN_ARCH}/positron-workbench-linux-${PKG_ARCH}-${POSITRON_VERSION}.tar.gz" && \
+{% endif %}\
     tar -xzf /tmp/positron.tar.gz -C /tmp && \
     mv /tmp/vscode-reh-web-*linux-* /opt/positron/bin/positron-server/bundled && \
-    rm /tmp/positron.tar.gz && \
-    # Download positron docs from CDN
+    rm /tmp/positron.tar.gz{% if not is_dev %} && \
     mkdir -p /opt/positron/docs/positron && \
     curl -fsSL -o /tmp/docs.zip \
       "https://cdn.posit.co/positron/releases/docs/positron-workbench-docs-${POSITRON_VERSION}.zip" && \
     unzip -qo /tmp/docs.zip -d /opt/positron/docs/positron && \
-    rm /tmp/docs.zip && \
-    # Download latest positron-session-init binary from CDN
+    rm /tmp/docs.zip{% endif %} && \
     BINARY_URL=$(curl -fsSL "https://cdn.posit.co/pwb-components/positron-session-init/latest.json" \
       | jq -r ".artifacts[\"${INIT_ARTIFACT}\"].url") && \
     curl -fsSL -o /tmp/positron-session-init.tar.gz "$BINARY_URL" && \
@@ -58,6 +56,12 @@ LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04"
 ARG DEBIAN_FRONTEND=noninteractive
 
 {{ apt.run_update_upgrade() }}
+
+{% if is_dev %}
+ENV PWB_POSITRON_TARGET="positron"
+{% else %}
+ENV PWB_POSITRON_TARGET="positron,positron-docs"
+{% endif %}
 
 COPY --from=builder --chmod=755 /usr/local/bin/positron-session-init /usr/local/bin/positron-session-init
 COPY --from=builder --chmod=755 /opt/positron /opt/positron

--- a/workbench-positron-init/template/Containerfile.ubuntu2404.jinja2
+++ b/workbench-positron-init/template/Containerfile.ubuntu2404.jinja2
@@ -11,6 +11,8 @@ ARG BUILDARCH
 ARG TARGETARCH=${BUILDARCH}
 {% if not is_dev %}ARG POSITRON_VERSION{% endif %}
 
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
 {{ apt.run_setup() }}
 
 RUN apt-get update -qq && \


### PR DESCRIPTION
Positron daily builds need a preview image path so they can be tested in Workbench before a stable release ships. This wires \`workbench-positron-init\` into the dev-build pipeline: a \`sourceType: dependency\` dev version resolves the latest daily build via the Positron dependency's prerelease channel and pushes to \`ghcr.io/posit-dev/workbench-positron-init-preview\`.

Daily builds skip docs (not published to the dailies CDN) with a best-effort download wrapped in \`|| true\` so missing docs don't fail the build. The version is baked into the CDN URL at render time rather than passed as a build arg, since dailies aren't addressable by a stable version string at build time.

\`channel: daily\` marks this dev version's release channel in image metadata, plumbing it in for future tag patterns and in anticipation of a second \`channel: preview\` entry for certification builds.

The \`REVERTME\` commit pins the workflows and bakery install to the \`positron-init-preview-stream\` branch so CI can validate this before the images-shared stack merges. It must be reverted before this PR merges.

Depends on (must merge first):
- https://github.com/posit-dev/images-shared/pull/565
- https://github.com/posit-dev/images-shared/pull/567