### PR TITLE
Notify Slack on merge queue failures

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,8 @@
 name: Pull Request
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
 
 
 concurrency:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -59,6 +59,7 @@ jobs:
     with:
       dev-versions: "exclude"
       matrix-versions: "exclude"
+      latest-only: ${{ github.event_name != 'merge_group' }}
 
   development:
     name: Development
@@ -69,6 +70,7 @@ jobs:
     with:
       dev-versions: "only"
       matrix-versions: "exclude"
+      latest-only: ${{ github.event_name != 'merge_group' }}
 
   session:
     name: Session
@@ -78,6 +80,7 @@ jobs:
     uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
     with:
       matrix-versions: "only"
+      latest-only: ${{ github.event_name != 'merge_group' }}
 
   zizmor:
     name: Zizmor

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,6 @@ name: Pull Request
 on:
   pull_request:
   merge_group:
-    types: [checks_requested]
 
 
 concurrency:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,8 +55,9 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
+    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@feat/merge-queue-slack-notifications
     with:
+      version: feat/merge-queue-slack-notifications
       dev-versions: "exclude"
       matrix-versions: "exclude"
       latest-only: ${{ github.event_name != 'merge_group' }}
@@ -66,8 +67,9 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
+    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@feat/merge-queue-slack-notifications
     with:
+      version: feat/merge-queue-slack-notifications
       dev-versions: "only"
       matrix-versions: "exclude"
       latest-only: ${{ github.event_name != 'merge_group' }}
@@ -77,8 +79,9 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
+    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@feat/merge-queue-slack-notifications
     with:
+      version: feat/merge-queue-slack-notifications
       matrix-versions: "only"
       latest-only: ${{ github.event_name != 'merge_group' }}
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,8 +22,15 @@ jobs:
       - zizmor
     steps:
       - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # v1.2.2
+        id: alls-green
         with:
           jobs: ${{ toJSON(needs) }}
+      - if: always() && github.event_name == 'merge_group'
+        continue-on-error: true
+        uses: posit-dev/images-shared/.github/actions/slack-build-notify@main
+        with:
+          result: ${{ steps.alls-green.outcome }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   lint:
     name: Lint


### PR DESCRIPTION
Adds a Slack notification step to the PR workflow that fires when a
merge queue run fails.

The `merge_group` trigger is required for the workflow to run during
merge queue checks at all. Without it, the `github.event_name ==
'merge_group'` condition in the notification step was never satisfied.