### PR TITLE
Add ARM platform to Workbench 2026.05.0

### DIFF
--- a/bakery.yaml
+++ b/bakery.yaml
@@ -105,6 +105,9 @@ images:
           - name: Ubuntu 22.04
           - name: Ubuntu 24.04
             primary: true
+            platforms:
+              - linux/amd64
+              - linux/arm64
         dependencies:
           - dependency: R
             version: 4.6.0
@@ -191,6 +194,9 @@ images:
         os:
           - name: Ubuntu 24.04
             primary: true
+            platforms:
+              - linux/amd64
+              - linux/arm64
       - name: 2026.04.0+526.pro2
         subpath: '2026.04'
         os:

--- a/bakery.yaml
+++ b/bakery.yaml
@@ -94,6 +94,9 @@ images:
           - name: Ubuntu 22.04
           - name: Ubuntu 24.04
             primary: true
+            platforms:
+              - linux/amd64
+              - linux/arm64
         dependencies:
           - dependency: R
             version: 4.6.1
@@ -189,6 +192,9 @@ images:
         os:
           - name: Ubuntu 24.04
             primary: true
+            platforms:
+              - linux/amd64
+              - linux/arm64
       - name: 2026.05.1+225.pro10
         subpath: '2026.05'
         os:

--- a/workbench-positron-init/matrix/Containerfile.ubuntu2404
+++ b/workbench-positron-init/matrix/Containerfile.ubuntu2404
@@ -65,8 +65,7 @@ LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
-    apt-get update -yqq --fix-missing && \
+RUN apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/workbench-session-init/2025.09/test/goss.yaml
+++ b/workbench-session-init/2025.09/test/goss.yaml
@@ -19,10 +19,6 @@ file:
     exists: true
     filetype: directory
     mode: "0755"
-  /opt/session-components/bin/opensuse15:
-    exists: true
-    filetype: directory
-    mode: "0755"
   /opt/session-components/bin/postback:
     exists: true
     filetype: directory
@@ -39,14 +35,26 @@ file:
     exists: true
     filetype: file
     mode: "0755"
-  /opt/session-components/bin/rhel8:
-    exists: true
-    filetype: directory
-    mode: "0755"
   /opt/session-components/bin/rhel9:
     exists: true
     filetype: directory
     mode: "0755"
+  /opt/session-components/bin/rhel10:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  # opensuse15 and rhel8 are only shipped in the amd64 build of the
+  # upstream rsp-session-multi-linux tarball.
+  {{- if eq .Env.IMAGE_OS_PLATFORM "linux/amd64" }}
+  /opt/session-components/bin/opensuse15:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  /opt/session-components/bin/rhel8:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  {{- end }}
   /opt/session-components/bin/shared-run:
     exists: true
     filetype: file

--- a/workbench-session-init/2025.09/test/goss.yaml
+++ b/workbench-session-init/2025.09/test/goss.yaml
@@ -43,9 +43,6 @@ file:
     exists: true
     filetype: directory
     mode: "0755"
-  # opensuse15 and rhel8 are only shipped in the amd64 build of the
-  # upstream rsp-session-multi-linux tarball.
-  {{- if eq .Env.IMAGE_OS_PLATFORM "linux/amd64" }}
   /opt/session-components/bin/opensuse15:
     exists: true
     filetype: directory
@@ -54,7 +51,6 @@ file:
     exists: true
     filetype: directory
     mode: "0755"
-  {{- end }}
   /opt/session-components/bin/shared-run:
     exists: true
     filetype: file

--- a/workbench-session-init/2026.01/test/goss.yaml
+++ b/workbench-session-init/2026.01/test/goss.yaml
@@ -19,10 +19,6 @@ file:
     exists: true
     filetype: directory
     mode: "0755"
-  /opt/session-components/bin/opensuse15:
-    exists: true
-    filetype: directory
-    mode: "0755"
   /opt/session-components/bin/postback:
     exists: true
     filetype: directory
@@ -39,14 +35,26 @@ file:
     exists: true
     filetype: file
     mode: "0755"
-  /opt/session-components/bin/rhel8:
-    exists: true
-    filetype: directory
-    mode: "0755"
   /opt/session-components/bin/rhel9:
     exists: true
     filetype: directory
     mode: "0755"
+  /opt/session-components/bin/rhel10:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  # opensuse15 and rhel8 are only shipped in the amd64 build of the
+  # upstream rsp-session-multi-linux tarball.
+  {{- if eq .Env.IMAGE_OS_PLATFORM "linux/amd64" }}
+  /opt/session-components/bin/opensuse15:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  /opt/session-components/bin/rhel8:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  {{- end }}
   /opt/session-components/bin/shared-run:
     exists: true
     filetype: file

--- a/workbench-session-init/2026.01/test/goss.yaml
+++ b/workbench-session-init/2026.01/test/goss.yaml
@@ -43,9 +43,6 @@ file:
     exists: true
     filetype: directory
     mode: "0755"
-  # opensuse15 and rhel8 are only shipped in the amd64 build of the
-  # upstream rsp-session-multi-linux tarball.
-  {{- if eq .Env.IMAGE_OS_PLATFORM "linux/amd64" }}
   /opt/session-components/bin/opensuse15:
     exists: true
     filetype: directory
@@ -54,7 +51,6 @@ file:
     exists: true
     filetype: directory
     mode: "0755"
-  {{- end }}
   /opt/session-components/bin/shared-run:
     exists: true
     filetype: file

--- a/workbench-session-init/2026.04/test/goss.yaml
+++ b/workbench-session-init/2026.04/test/goss.yaml
@@ -19,10 +19,6 @@ file:
     exists: true
     filetype: directory
     mode: "0755"
-  /opt/session-components/bin/opensuse15:
-    exists: true
-    filetype: directory
-    mode: "0755"
   /opt/session-components/bin/postback:
     exists: true
     filetype: directory
@@ -39,14 +35,26 @@ file:
     exists: true
     filetype: file
     mode: "0755"
-  /opt/session-components/bin/rhel8:
-    exists: true
-    filetype: directory
-    mode: "0755"
   /opt/session-components/bin/rhel9:
     exists: true
     filetype: directory
     mode: "0755"
+  /opt/session-components/bin/rhel10:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  # opensuse15 and rhel8 are only shipped in the amd64 build of the
+  # upstream rsp-session-multi-linux tarball.
+  {{- if eq .Env.IMAGE_OS_PLATFORM "linux/amd64" }}
+  /opt/session-components/bin/opensuse15:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  /opt/session-components/bin/rhel8:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  {{- end }}
   /opt/session-components/bin/shared-run:
     exists: true
     filetype: file

--- a/workbench-session-init/2026.04/test/goss.yaml
+++ b/workbench-session-init/2026.04/test/goss.yaml
@@ -43,9 +43,6 @@ file:
     exists: true
     filetype: directory
     mode: "0755"
-  # opensuse15 and rhel8 are only shipped in the amd64 build of the
-  # upstream rsp-session-multi-linux tarball.
-  {{- if eq .Env.IMAGE_OS_PLATFORM "linux/amd64" }}
   /opt/session-components/bin/opensuse15:
     exists: true
     filetype: directory
@@ -54,7 +51,6 @@ file:
     exists: true
     filetype: directory
     mode: "0755"
-  {{- end }}
   /opt/session-components/bin/shared-run:
     exists: true
     filetype: file

--- a/workbench/2025.09/Containerfile.ubuntu2204.min
+++ b/workbench/2025.09/Containerfile.ubuntu2204.min
@@ -20,6 +20,7 @@ ENV PWB_DIAGNOSTIC_DIR=/var/log/rstudio
 ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
 
+
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###

--- a/workbench/2025.09/Containerfile.ubuntu2204.std
+++ b/workbench/2025.09/Containerfile.ubuntu2204.std
@@ -30,6 +30,7 @@ ENV PWB_DIAGNOSTIC_DIR=/var/log/rstudio
 ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
 
+
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###

--- a/workbench/2025.09/Containerfile.ubuntu2404.min
+++ b/workbench/2025.09/Containerfile.ubuntu2404.min
@@ -22,6 +22,7 @@ ENV PWB_EXIT_AFTER_VERIFY=false
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+
 ### Setup environment ###
 RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
     apt-get update -yqq --fix-missing && \

--- a/workbench/2025.09/Containerfile.ubuntu2404.std
+++ b/workbench/2025.09/Containerfile.ubuntu2404.std
@@ -32,6 +32,7 @@ ENV PWB_EXIT_AFTER_VERIFY=false
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+
 ### Setup environment ###
 RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
     apt-get update -yqq --fix-missing && \

--- a/workbench/2026.01/Containerfile.ubuntu2204.min
+++ b/workbench/2026.01/Containerfile.ubuntu2204.min
@@ -20,6 +20,7 @@ ENV PWB_DIAGNOSTIC_DIR=/var/log/rstudio
 ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
 
+
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###

--- a/workbench/2026.01/Containerfile.ubuntu2204.std
+++ b/workbench/2026.01/Containerfile.ubuntu2204.std
@@ -30,6 +30,7 @@ ENV PWB_DIAGNOSTIC_DIR=/var/log/rstudio
 ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
 
+
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###

--- a/workbench/2026.01/Containerfile.ubuntu2404.min
+++ b/workbench/2026.01/Containerfile.ubuntu2404.min
@@ -22,6 +22,7 @@ ENV PWB_EXIT_AFTER_VERIFY=false
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+
 ### Setup environment ###
 RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
     apt-get update -yqq --fix-missing && \

--- a/workbench/2026.01/Containerfile.ubuntu2404.std
+++ b/workbench/2026.01/Containerfile.ubuntu2404.std
@@ -32,6 +32,7 @@ ENV PWB_EXIT_AFTER_VERIFY=false
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+
 ### Setup environment ###
 RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
     apt-get update -yqq --fix-missing && \

--- a/workbench/2026.04/Containerfile.ubuntu2204.min
+++ b/workbench/2026.04/Containerfile.ubuntu2204.min
@@ -20,6 +20,7 @@ ENV PWB_DIAGNOSTIC_DIR=/var/log/rstudio
 ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
 
+
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###

--- a/workbench/2026.04/Containerfile.ubuntu2204.std
+++ b/workbench/2026.04/Containerfile.ubuntu2204.std
@@ -30,6 +30,7 @@ ENV PWB_DIAGNOSTIC_DIR=/var/log/rstudio
 ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
 
+
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
@@ -122,6 +123,12 @@ RUN mkdir -p /var/lib/rstudio-server/monitor/log \
 ### Install TinyTeX using Quarto ###
 # Caches won't invalidate correctly on new releases for TinyTeX installs. This ADD instruction is a workaround to bust
 # the cache on new releases.
+#
+# TinyTeX is installed under HOME="/opt" so the install lands at /opt/.TinyTeX,
+# which is readable by non-root runtime users. `--update-path` makes tlmgr
+# symlink the TinyTeX binaries into /usr/local/bin.
+# TODO: Remove `HOME="/opt"` once Quarto supports custom install locations
+# for TinyTeX, see https://github.com/quarto-dev/quarto-cli/issues/11800.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
     GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --update-path \

--- a/workbench/2026.04/Containerfile.ubuntu2404.min
+++ b/workbench/2026.04/Containerfile.ubuntu2404.min
@@ -22,6 +22,7 @@ ENV PWB_EXIT_AFTER_VERIFY=false
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+
 ### Setup environment ###
 RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
     apt-get update -yqq --fix-missing && \

--- a/workbench/2026.04/Containerfile.ubuntu2404.std
+++ b/workbench/2026.04/Containerfile.ubuntu2404.std
@@ -32,6 +32,7 @@ ENV PWB_EXIT_AFTER_VERIFY=false
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+
 ### Setup environment ###
 RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
     apt-get update -yqq --fix-missing && \
@@ -122,6 +123,12 @@ RUN mkdir -p /var/lib/rstudio-server/monitor/log \
 ### Install TinyTeX using Quarto ###
 # Caches won't invalidate correctly on new releases for TinyTeX installs. This ADD instruction is a workaround to bust
 # the cache on new releases.
+#
+# TinyTeX is installed under HOME="/opt" so the install lands at /opt/.TinyTeX,
+# which is readable by non-root runtime users. `--update-path` makes tlmgr
+# symlink the TinyTeX binaries into /usr/local/bin.
+# TODO: Remove `HOME="/opt"` once Quarto supports custom install locations
+# for TinyTeX, see https://github.com/quarto-dev/quarto-cli/issues/11800.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
     GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --update-path \


### PR DESCRIPTION
ARM packages are now availble in the deb/rpm repos.

Enable platform on recent image
