### PR TITLE
Add deprecate-editions workflow; switch release to client-id

### DIFF
--- a/.github/workflows/deprecate.yml
+++ b/.github/workflows/deprecate.yml
@@ -1,0 +1,19 @@
+name: Deprecate Editions
+
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch: {}
+
+jobs:
+  deprecate:
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: posit-dev/images-shared/.github/workflows/deprecate-editions.yml@main
+    with:
+      images: "workbench workbench-session-init"
+      update-positron-min: true
+    secrets:
+      CLIENT_ID: ${{ secrets.WORKBENCH_IDE_RELEASE_CLIENT_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.WORKBENCH_IDE_RELEASE_PEM }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       version: ${{ inputs.version }}
       images: "workbench workbench-session-init"
     secrets:
-      APP_ID: ${{ secrets.WORKBENCH_IDE_RELEASE_APP_ID }}
+      CLIENT_ID: ${{ secrets.WORKBENCH_IDE_RELEASE_CLIENT_ID }}
       APP_PRIVATE_KEY: ${{ secrets.WORKBENCH_IDE_RELEASE_PEM }}
 
   trigger-specialized:
@@ -31,7 +31,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
-          app-id: ${{ secrets.WORKBENCH_IDE_RELEASE_APP_ID }}
+          client-id: ${{ secrets.WORKBENCH_IDE_RELEASE_CLIENT_ID }}
           private-key: ${{ secrets.WORKBENCH_IDE_RELEASE_PEM }}
           owner: posit-dev
           repositories: images-specialized

--- a/bakery.yaml
+++ b/bakery.yaml
@@ -76,6 +76,9 @@ images:
           - name: Ubuntu 22.04
           - name: Ubuntu 24.04
             primary: true
+            platforms:
+              - linux/amd64
+              - linux/arm64
         dependencies:
           - dependency: R
             version: 4.6.0
@@ -140,6 +143,9 @@ images:
         os:
           - name: Ubuntu 24.04
             primary: true
+            platforms:
+              - linux/amd64
+              - linux/arm64
       - name: 2026.04.0+526.pro2
         subpath: '2026.04'
         os:

--- a/workbench-positron-init/matrix/Containerfile.ubuntu2404
+++ b/workbench-positron-init/matrix/Containerfile.ubuntu2404
@@ -64,8 +64,7 @@ LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
-    apt-get update -yqq --fix-missing && \
+RUN apt-get update -yqq --fix-missing && \
     apt-get upgrade -yqq && \
     apt-get dist-upgrade -yqq && \
     apt-get autoremove -yqq --purge && \

--- a/workbench-session-init/2025.09/test/goss.yaml
+++ b/workbench-session-init/2025.09/test/goss.yaml
@@ -19,10 +19,6 @@ file:
     exists: true
     filetype: directory
     mode: "0755"
-  /opt/session-components/bin/opensuse15:
-    exists: true
-    filetype: directory
-    mode: "0755"
   /opt/session-components/bin/postback:
     exists: true
     filetype: directory
@@ -39,14 +35,26 @@ file:
     exists: true
     filetype: file
     mode: "0755"
-  /opt/session-components/bin/rhel8:
-    exists: true
-    filetype: directory
-    mode: "0755"
   /opt/session-components/bin/rhel9:
     exists: true
     filetype: directory
     mode: "0755"
+  /opt/session-components/bin/rhel10:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  # opensuse15 and rhel8 are only shipped in the amd64 build of the
+  # upstream rsp-session-multi-linux tarball.
+  {{- if eq .Env.IMAGE_OS_PLATFORM "linux/amd64" }}
+  /opt/session-components/bin/opensuse15:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  /opt/session-components/bin/rhel8:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  {{- end }}
   /opt/session-components/bin/shared-run:
     exists: true
     filetype: file

--- a/workbench-session-init/2025.09/test/goss.yaml
+++ b/workbench-session-init/2025.09/test/goss.yaml
@@ -43,9 +43,6 @@ file:
     exists: true
     filetype: directory
     mode: "0755"
-  # opensuse15 and rhel8 are only shipped in the amd64 build of the
-  # upstream rsp-session-multi-linux tarball.
-  {{- if eq .Env.IMAGE_OS_PLATFORM "linux/amd64" }}
   /opt/session-components/bin/opensuse15:
     exists: true
     filetype: directory
@@ -54,7 +51,6 @@ file:
     exists: true
     filetype: directory
     mode: "0755"
-  {{- end }}
   /opt/session-components/bin/shared-run:
     exists: true
     filetype: file

--- a/workbench-session-init/2026.01/test/goss.yaml
+++ b/workbench-session-init/2026.01/test/goss.yaml
@@ -19,10 +19,6 @@ file:
     exists: true
     filetype: directory
     mode: "0755"
-  /opt/session-components/bin/opensuse15:
-    exists: true
-    filetype: directory
-    mode: "0755"
   /opt/session-components/bin/postback:
     exists: true
     filetype: directory
@@ -39,14 +35,26 @@ file:
     exists: true
     filetype: file
     mode: "0755"
-  /opt/session-components/bin/rhel8:
-    exists: true
-    filetype: directory
-    mode: "0755"
   /opt/session-components/bin/rhel9:
     exists: true
     filetype: directory
     mode: "0755"
+  /opt/session-components/bin/rhel10:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  # opensuse15 and rhel8 are only shipped in the amd64 build of the
+  # upstream rsp-session-multi-linux tarball.
+  {{- if eq .Env.IMAGE_OS_PLATFORM "linux/amd64" }}
+  /opt/session-components/bin/opensuse15:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  /opt/session-components/bin/rhel8:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  {{- end }}
   /opt/session-components/bin/shared-run:
     exists: true
     filetype: file

--- a/workbench-session-init/2026.01/test/goss.yaml
+++ b/workbench-session-init/2026.01/test/goss.yaml
@@ -43,9 +43,6 @@ file:
     exists: true
     filetype: directory
     mode: "0755"
-  # opensuse15 and rhel8 are only shipped in the amd64 build of the
-  # upstream rsp-session-multi-linux tarball.
-  {{- if eq .Env.IMAGE_OS_PLATFORM "linux/amd64" }}
   /opt/session-components/bin/opensuse15:
     exists: true
     filetype: directory
@@ -54,7 +51,6 @@ file:
     exists: true
     filetype: directory
     mode: "0755"
-  {{- end }}
   /opt/session-components/bin/shared-run:
     exists: true
     filetype: file

--- a/workbench-session-init/2026.04/test/goss.yaml
+++ b/workbench-session-init/2026.04/test/goss.yaml
@@ -19,10 +19,6 @@ file:
     exists: true
     filetype: directory
     mode: "0755"
-  /opt/session-components/bin/opensuse15:
-    exists: true
-    filetype: directory
-    mode: "0755"
   /opt/session-components/bin/postback:
     exists: true
     filetype: directory
@@ -39,14 +35,26 @@ file:
     exists: true
     filetype: file
     mode: "0755"
-  /opt/session-components/bin/rhel8:
-    exists: true
-    filetype: directory
-    mode: "0755"
   /opt/session-components/bin/rhel9:
     exists: true
     filetype: directory
     mode: "0755"
+  /opt/session-components/bin/rhel10:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  # opensuse15 and rhel8 are only shipped in the amd64 build of the
+  # upstream rsp-session-multi-linux tarball.
+  {{- if eq .Env.IMAGE_OS_PLATFORM "linux/amd64" }}
+  /opt/session-components/bin/opensuse15:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  /opt/session-components/bin/rhel8:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  {{- end }}
   /opt/session-components/bin/shared-run:
     exists: true
     filetype: file

--- a/workbench-session-init/2026.04/test/goss.yaml
+++ b/workbench-session-init/2026.04/test/goss.yaml
@@ -43,9 +43,6 @@ file:
     exists: true
     filetype: directory
     mode: "0755"
-  # opensuse15 and rhel8 are only shipped in the amd64 build of the
-  # upstream rsp-session-multi-linux tarball.
-  {{- if eq .Env.IMAGE_OS_PLATFORM "linux/amd64" }}
   /opt/session-components/bin/opensuse15:
     exists: true
     filetype: directory
@@ -54,7 +51,6 @@ file:
     exists: true
     filetype: directory
     mode: "0755"
-  {{- end }}
   /opt/session-components/bin/shared-run:
     exists: true
     filetype: file

--- a/workbench-session-init/2026.05/test/goss.yaml
+++ b/workbench-session-init/2026.05/test/goss.yaml
@@ -19,10 +19,6 @@ file:
     exists: true
     filetype: directory
     mode: "0755"
-  /opt/session-components/bin/opensuse15:
-    exists: true
-    filetype: directory
-    mode: "0755"
   /opt/session-components/bin/postback:
     exists: true
     filetype: directory
@@ -39,14 +35,26 @@ file:
     exists: true
     filetype: file
     mode: "0755"
-  /opt/session-components/bin/rhel8:
-    exists: true
-    filetype: directory
-    mode: "0755"
   /opt/session-components/bin/rhel9:
     exists: true
     filetype: directory
     mode: "0755"
+  /opt/session-components/bin/rhel10:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  # opensuse15 and rhel8 are only shipped in the amd64 build of the
+  # upstream rsp-session-multi-linux tarball.
+  {{- if eq .Env.IMAGE_OS_PLATFORM "linux/amd64" }}
+  /opt/session-components/bin/opensuse15:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  /opt/session-components/bin/rhel8:
+    exists: true
+    filetype: directory
+    mode: "0755"
+  {{- end }}
   /opt/session-components/bin/shared-run:
     exists: true
     filetype: file

--- a/workbench/2025.09/Containerfile.ubuntu2204.min
+++ b/workbench/2025.09/Containerfile.ubuntu2204.min
@@ -20,6 +20,7 @@ ENV PWB_DIAGNOSTIC_DIR=/var/log/rstudio
 ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
 
+
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###

--- a/workbench/2025.09/Containerfile.ubuntu2204.std
+++ b/workbench/2025.09/Containerfile.ubuntu2204.std
@@ -30,6 +30,7 @@ ENV PWB_DIAGNOSTIC_DIR=/var/log/rstudio
 ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
 
+
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###

--- a/workbench/2025.09/Containerfile.ubuntu2404.min
+++ b/workbench/2025.09/Containerfile.ubuntu2404.min
@@ -22,6 +22,7 @@ ENV PWB_EXIT_AFTER_VERIFY=false
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+
 ### Setup environment ###
 RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
     apt-get update -yqq --fix-missing && \

--- a/workbench/2025.09/Containerfile.ubuntu2404.std
+++ b/workbench/2025.09/Containerfile.ubuntu2404.std
@@ -32,6 +32,7 @@ ENV PWB_EXIT_AFTER_VERIFY=false
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+
 ### Setup environment ###
 RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
     apt-get update -yqq --fix-missing && \

--- a/workbench/2026.01/Containerfile.ubuntu2204.min
+++ b/workbench/2026.01/Containerfile.ubuntu2204.min
@@ -20,6 +20,7 @@ ENV PWB_DIAGNOSTIC_DIR=/var/log/rstudio
 ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
 
+
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###

--- a/workbench/2026.01/Containerfile.ubuntu2204.std
+++ b/workbench/2026.01/Containerfile.ubuntu2204.std
@@ -30,6 +30,7 @@ ENV PWB_DIAGNOSTIC_DIR=/var/log/rstudio
 ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
 
+
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###

--- a/workbench/2026.01/Containerfile.ubuntu2404.min
+++ b/workbench/2026.01/Containerfile.ubuntu2404.min
@@ -22,6 +22,7 @@ ENV PWB_EXIT_AFTER_VERIFY=false
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+
 ### Setup environment ###
 RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
     apt-get update -yqq --fix-missing && \

--- a/workbench/2026.01/Containerfile.ubuntu2404.std
+++ b/workbench/2026.01/Containerfile.ubuntu2404.std
@@ -32,6 +32,7 @@ ENV PWB_EXIT_AFTER_VERIFY=false
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+
 ### Setup environment ###
 RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
     apt-get update -yqq --fix-missing && \

--- a/workbench/2026.04/Containerfile.ubuntu2204.min
+++ b/workbench/2026.04/Containerfile.ubuntu2204.min
@@ -20,6 +20,7 @@ ENV PWB_DIAGNOSTIC_DIR=/var/log/rstudio
 ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
 
+
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###

--- a/workbench/2026.04/Containerfile.ubuntu2204.std
+++ b/workbench/2026.04/Containerfile.ubuntu2204.std
@@ -30,6 +30,7 @@ ENV PWB_DIAGNOSTIC_DIR=/var/log/rstudio
 ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
 
+
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###
@@ -122,6 +123,12 @@ RUN mkdir -p /var/lib/rstudio-server/monitor/log \
 ### Install TinyTeX using Quarto ###
 # Caches won't invalidate correctly on new releases for TinyTeX installs. This ADD instruction is a workaround to bust
 # the cache on new releases.
+#
+# TinyTeX is installed under HOME="/opt" so the install lands at /opt/.TinyTeX,
+# which is readable by non-root runtime users. `--update-path` makes tlmgr
+# symlink the TinyTeX binaries into /usr/local/bin.
+# TODO: Remove `HOME="/opt"` once Quarto supports custom install locations
+# for TinyTeX, see https://github.com/quarto-dev/quarto-cli/issues/11800.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
     GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --update-path \

--- a/workbench/2026.04/Containerfile.ubuntu2404.min
+++ b/workbench/2026.04/Containerfile.ubuntu2404.min
@@ -22,6 +22,7 @@ ENV PWB_EXIT_AFTER_VERIFY=false
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+
 ### Setup environment ###
 RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
     apt-get update -yqq --fix-missing && \

--- a/workbench/2026.04/Containerfile.ubuntu2404.std
+++ b/workbench/2026.04/Containerfile.ubuntu2404.std
@@ -32,6 +32,7 @@ ENV PWB_EXIT_AFTER_VERIFY=false
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+
 ### Setup environment ###
 RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
     apt-get update -yqq --fix-missing && \
@@ -122,6 +123,12 @@ RUN mkdir -p /var/lib/rstudio-server/monitor/log \
 ### Install TinyTeX using Quarto ###
 # Caches won't invalidate correctly on new releases for TinyTeX installs. This ADD instruction is a workaround to bust
 # the cache on new releases.
+#
+# TinyTeX is installed under HOME="/opt" so the install lands at /opt/.TinyTeX,
+# which is readable by non-root runtime users. `--update-path` makes tlmgr
+# symlink the TinyTeX binaries into /usr/local/bin.
+# TODO: Remove `HOME="/opt"` once Quarto supports custom install locations
+# for TinyTeX, see https://github.com/quarto-dev/quarto-cli/issues/11800.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
     GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --update-path \

--- a/workbench/2026.05/Containerfile.ubuntu2204.min
+++ b/workbench/2026.05/Containerfile.ubuntu2204.min
@@ -20,6 +20,7 @@ ENV PWB_DIAGNOSTIC_DIR=/var/log/rstudio
 ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
 
+
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###

--- a/workbench/2026.05/Containerfile.ubuntu2204.std
+++ b/workbench/2026.05/Containerfile.ubuntu2204.std
@@ -30,6 +30,7 @@ ENV PWB_DIAGNOSTIC_DIR=/var/log/rstudio
 ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
 
+
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 ### Setup environment ###

--- a/workbench/2026.05/Containerfile.ubuntu2404.min
+++ b/workbench/2026.05/Containerfile.ubuntu2404.min
@@ -22,6 +22,7 @@ ENV PWB_EXIT_AFTER_VERIFY=false
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+
 ### Setup environment ###
 RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
     apt-get update -yqq --fix-missing && \

--- a/workbench/2026.05/Containerfile.ubuntu2404.std
+++ b/workbench/2026.05/Containerfile.ubuntu2404.std
@@ -32,6 +32,7 @@ ENV PWB_EXIT_AFTER_VERIFY=false
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+
 ### Setup environment ###
 RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
     apt-get update -yqq --fix-missing && \


### PR DESCRIPTION
Adds a scheduled workflow that runs on the 1st of each month and creates a PR to remove product editions older than 18 months (per the Posit supported-versions policy). This stops those editions from being built going forward — it does not remove any already-published images from Docker Hub or GHCR. For workbench, also updates the `workbench-positron-init` `min` constraint to track the same 18-month window.

Also switches both the release workflow and the inline `trigger-specialized` token step from the legacy `app-id` GitHub App input to `client-id`, as recommended by `actions/create-github-app-token`.

Depends on posit-dev/images-shared being merged first.