### PR TITLE
Allow dispatching a daily build for a non-mainline version

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -10,6 +10,10 @@ on:
         description: "Dev stream to build (e.g. 'daily')"
         required: false
         type: string
+      release-branch:
+        description: "Release branch for the dailies index (e.g. '2026.05'). Default 'latest' = mainline. Use to build a daily for a non-mainline version line."
+        required: false
+        type: string
 
   schedule:
     # Daily rebuild of dev images. Staggered with images-package-manager
@@ -71,6 +75,9 @@ jobs:
       matrix-versions: "exclude"
       image-version: ${{ inputs.version }}
       dev-stream: ${{ inputs.stream }}
+      # Empty on scheduled/push runs; fall back to mainline so we don't override
+      # the reusable workflow's default with an empty release branch.
+      release-branch: ${{ inputs.release-branch || 'latest' }}
       # Push on merges to main, scheduled rebuilds, and dispatches targeting main.
       push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
 


### PR DESCRIPTION
## What

Adds a `release-branch` `workflow_dispatch` input to the **Development** workflow and passes it through to the shared `bakery-build-native.yml` reusable workflow.

This lets you dispatch a daily build for a **non-mainline** Workbench version line (e.g. a `2026.05` daily) instead of only the mainline `latest` daily stream.

## How it works

The daily stream URL in bakery is built from `BAKERY_WORKBENCH_RELEASE_BRANCH` (`images-shared` `posit_product/const.py`), defaulting to `latest`. The dailies endpoint serves per-branch indexes by version number, e.g. `https://dailies.rstudio.com/rstudio/2026.05/index.json`.

- New `release-branch` dispatch input (e.g. `2026.05`).
- Passed as `release-branch: ${{ inputs.release-branch || 'latest' }}`. The `|| 'latest'` fallback is required because `inputs.release-branch` is empty on scheduled/push runs, and passing an empty string would override the reusable workflow's default and break the dailies URL (an empty env var is *not* the same as unset).

## Usage

Dispatch **Development** with `release-branch: 2026.05` (leave `version`/`stream` empty) to build the latest 2026.05 daily into `ghcr.io/posit-dev/workbench-preview`.

## ⚠️ Depends on images-shared

Requires the companion `release-branch` input on `images-shared`'s `bakery-build-native.yml`. **That PR must merge first** (this workflow pins `@main`), otherwise the input is ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)