### PR TITLE
Add Workbench preview release stream

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -10,6 +10,10 @@ on:
         description: "Dev stream to build (e.g. 'daily')"
         required: false
         type: string
+      release-branch:
+        description: "Workbench dailies release branch (e.g. 'apple-blossom'). Overrides bakery.yaml release_branch."
+        required: false
+        type: string
 
   schedule:
     # Daily rebuild of dev images. Staggered with images-package-manager
@@ -71,6 +75,7 @@ jobs:
       matrix-versions: "exclude"
       image-version: ${{ inputs.version }}
       dev-stream: ${{ inputs.stream }}
+      release-branch: ${{ inputs.release-branch }}
       # Push on merges to main, scheduled rebuilds, and dispatches targeting main.
       push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
 

--- a/bakery.yaml
+++ b/bakery.yaml
@@ -60,6 +60,7 @@ images:
       - sourceType: stream
         product: workbench
         stream: daily
+        release_branch: "apple-blossom"
         os:
           - name: Ubuntu 24.04
             primary: true
@@ -128,6 +129,7 @@ images:
       - sourceType: stream
         product: workbench-session
         stream: daily
+        release_branch: "apple-blossom"
         # Runtime binary is arch-specific, not OS-specific; Ubuntu 24.04 only.
         os:
           - name: Ubuntu 24.04

--- a/bakery.yaml
+++ b/bakery.yaml
@@ -59,8 +59,7 @@ images:
     devVersions:
       - sourceType: stream
         product: workbench
-        stream: daily
-        release_branch: "apple-blossom"
+        channel: preview
         os:
           - name: Ubuntu 24.04
             primary: true
@@ -129,7 +128,6 @@ images:
       - sourceType: stream
         product: workbench-session
         stream: daily
-        release_branch: "apple-blossom"
         # Runtime binary is arch-specific, not OS-specific; Ubuntu 24.04 only.
         os:
           - name: Ubuntu 24.04


### PR DESCRIPTION
Configures daily dev version builds for the Workbench preview (apple-blossom)
branch, pushing to `ghcr.io/posit-dev/workbench-preview` and
`ghcr.io/posit-dev/workbench-session-init-preview`.

Uses the `release_branch` field introduced in the posit-bakery channel dev
version model to target the apple-blossom dailies URL. Update `release_branch`
in `bakery.yaml` when the preview branch rotates. The `release-branch`
dispatch input on `development.yml` allows overriding it at runtime without
changing `bakery.yaml`.

Requires:
- https://github.com/posit-dev/images-shared/pull/590