### PR TITLE
Add libnss_pwb NSS support to workbench-session (jammy + noble)

### DIFF
--- a/workbench-session/matrix/Containerfile.ubuntu2204
+++ b/workbench-session/matrix/Containerfile.ubuntu2204
@@ -52,6 +52,28 @@ RUN apt-get update -yqq && \
     rm -rf /var/lib/apt/lists/*
 RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
+### Enable the pwb NSS module for rootless in-session identity resolution ###
+# libnss_pwb.so is delivered at runtime by the workbench-session-init container
+# into /usr/lib/rstudio-server/bin/jammy/. Create the (build-time dangling)
+# multiarch symlink + nsswitch entries so glibc loads it once that volume is
+# populated. Dormant-safe: with no workbench-nss.conf the module returns
+# Unavail and resolution falls through to `files`.
+RUN case "${TARGETARCH}" in \
+      amd64) TRIPLET=x86_64-linux-gnu ;; \
+      arm64) TRIPLET=aarch64-linux-gnu ;; \
+      *) echo "unsupported arch ${TARGETARCH}"; exit 1 ;; \
+    esac && \
+    ln -sf /usr/lib/rstudio-server/bin/jammy/libnss_pwb.so \
+           "/usr/lib/${TRIPLET}/libnss_pwb.so.2" && \
+    for db in passwd group shadow; do \
+      touch /etc/nsswitch.conf; \
+      if grep -qE "^${db}:" /etc/nsswitch.conf; then \
+        sed -i -E "/^${db}:/ {/\bpwb\b/! s/\$/ pwb/}" /etc/nsswitch.conf; \
+      else \
+        echo "${db}: files pwb" >> /etc/nsswitch.conf; \
+      fi; \
+    done
+
 # Install Python from previous stage
 COPY --from=python-builder /opt/python /opt/python
 

--- a/workbench-session/matrix/Containerfile.ubuntu2404
+++ b/workbench-session/matrix/Containerfile.ubuntu2404
@@ -52,6 +52,28 @@ RUN apt-get update -yqq && \
     rm -rf /var/lib/apt/lists/*
 RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
+### Enable the pwb NSS module for rootless in-session identity resolution ###
+# libnss_pwb.so is delivered at runtime by the workbench-session-init container
+# into /usr/lib/rstudio-server/bin/noble/. Create the (build-time dangling)
+# multiarch symlink + nsswitch entries so glibc loads it once that volume is
+# populated. Dormant-safe: with no workbench-nss.conf the module returns
+# Unavail and resolution falls through to `files`.
+RUN case "${TARGETARCH}" in \
+      amd64) TRIPLET=x86_64-linux-gnu ;; \
+      arm64) TRIPLET=aarch64-linux-gnu ;; \
+      *) echo "unsupported arch ${TARGETARCH}"; exit 1 ;; \
+    esac && \
+    ln -sf /usr/lib/rstudio-server/bin/noble/libnss_pwb.so \
+           "/usr/lib/${TRIPLET}/libnss_pwb.so.2" && \
+    for db in passwd group shadow; do \
+      touch /etc/nsswitch.conf; \
+      if grep -qE "^${db}:" /etc/nsswitch.conf; then \
+        sed -i -E "/^${db}:/ {/\bpwb\b/! s/\$/ pwb/}" /etc/nsswitch.conf; \
+      else \
+        echo "${db}: files pwb" >> /etc/nsswitch.conf; \
+      fi; \
+    done
+
 # Install Python from previous stage
 COPY --from=python-builder /opt/python /opt/python
 

--- a/workbench-session/matrix/test/goss.yaml
+++ b/workbench-session/matrix/test/goss.yaml
@@ -33,6 +33,12 @@ file:
   /opt:
     exists: true
     filetype: directory
+  /etc/nsswitch.conf:
+    exists: true
+    contains:
+      - "/^passwd:.*\\bpwb\\b/"
+      - "/^group:.*\\bpwb\\b/"
+      - "/^shadow:.*\\bpwb\\b/"
 
 command:
   "Verify Jupyter Notebook works":
@@ -79,4 +85,7 @@ command:
     exit-status: 0
   "Verify /opt directories are world-traversable":
     exec: 'find /opt -type d -not -perm -005 -print 2>&1 | head -c1 | (! grep -q .)'
+    exit-status: 0
+  "Verify libnss_pwb symlink is present for current architecture":
+    exec: 'dpkg-architecture -qDEB_HOST_MULTIARCH | xargs -I{} test -L "/usr/lib/{}/libnss_pwb.so.2"'
     exit-status: 0

--- a/workbench-session/template/Containerfile.ubuntu2204.jinja2
+++ b/workbench-session/template/Containerfile.ubuntu2204.jinja2
@@ -33,6 +33,28 @@ COPY {{ Path.Version }}/deps/ubuntu-22.04_packages.txt /tmp/ubuntu-22.04_package
 {{ apt.run_install(packages="rstudio-drivers") }}
 RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
+### Enable the pwb NSS module for rootless in-session identity resolution ###
+# libnss_pwb.so is delivered at runtime by the workbench-session-init container
+# into /usr/lib/rstudio-server/bin/jammy/. Create the (build-time dangling)
+# multiarch symlink + nsswitch entries so glibc loads it once that volume is
+# populated. Dormant-safe: with no workbench-nss.conf the module returns
+# Unavail and resolution falls through to `files`.
+RUN case "${TARGETARCH}" in \
+      amd64) TRIPLET=x86_64-linux-gnu ;; \
+      arm64) TRIPLET=aarch64-linux-gnu ;; \
+      *) echo "unsupported arch ${TARGETARCH}"; exit 1 ;; \
+    esac && \
+    ln -sf /usr/lib/rstudio-server/bin/jammy/libnss_pwb.so \
+           "/usr/lib/${TRIPLET}/libnss_pwb.so.2" && \
+    for db in passwd group shadow; do \
+      touch /etc/nsswitch.conf; \
+      if grep -qE "^${db}:" /etc/nsswitch.conf; then \
+        sed -i -E "/^${db}:/ {/\bpwb\b/! s/\$/ pwb/}" /etc/nsswitch.conf; \
+      else \
+        echo "${db}: files pwb" >> /etc/nsswitch.conf; \
+      fi; \
+    done
+
 # Install Python from previous stage
 {{ python.copy_from_build_stage() }}
 

--- a/workbench-session/template/Containerfile.ubuntu2404.jinja2
+++ b/workbench-session/template/Containerfile.ubuntu2404.jinja2
@@ -33,6 +33,28 @@ COPY {{ Path.Version }}/deps/ubuntu-24.04_packages.txt /tmp/ubuntu-24.04_package
 {{ apt.run_install(packages="rstudio-drivers") }}
 RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
+### Enable the pwb NSS module for rootless in-session identity resolution ###
+# libnss_pwb.so is delivered at runtime by the workbench-session-init container
+# into /usr/lib/rstudio-server/bin/noble/. Create the (build-time dangling)
+# multiarch symlink + nsswitch entries so glibc loads it once that volume is
+# populated. Dormant-safe: with no workbench-nss.conf the module returns
+# Unavail and resolution falls through to `files`.
+RUN case "${TARGETARCH}" in \
+      amd64) TRIPLET=x86_64-linux-gnu ;; \
+      arm64) TRIPLET=aarch64-linux-gnu ;; \
+      *) echo "unsupported arch ${TARGETARCH}"; exit 1 ;; \
+    esac && \
+    ln -sf /usr/lib/rstudio-server/bin/noble/libnss_pwb.so \
+           "/usr/lib/${TRIPLET}/libnss_pwb.so.2" && \
+    for db in passwd group shadow; do \
+      touch /etc/nsswitch.conf; \
+      if grep -qE "^${db}:" /etc/nsswitch.conf; then \
+        sed -i -E "/^${db}:/ {/\bpwb\b/! s/\$/ pwb/}" /etc/nsswitch.conf; \
+      else \
+        echo "${db}: files pwb" >> /etc/nsswitch.conf; \
+      fi; \
+    done
+
 # Install Python from previous stage
 {{ python.copy_from_build_stage() }}
 

--- a/workbench-session/template/test/goss.yaml.jinja2
+++ b/workbench-session/template/test/goss.yaml.jinja2
@@ -40,6 +40,12 @@ file:
   /opt:
     exists: true
     filetype: directory
+  /etc/nsswitch.conf:
+    exists: true
+    contains:
+      - "/^passwd:.*\\bpwb\\b/"
+      - "/^group:.*\\bpwb\\b/"
+      - "/^shadow:.*\\bpwb\\b/"
 
 command:
   "Verify Jupyter Notebook works":
@@ -86,4 +92,7 @@ command:
     exit-status: 0
   "Verify /opt directories are world-traversable":
     exec: 'find /opt -type d -not -perm -005 -print 2>&1 | head -c1 | (! grep -q .)'
+    exit-status: 0
+  "Verify libnss_pwb symlink is present for current architecture":
+    exec: 'dpkg-architecture -qDEB_HOST_MULTIARCH | xargs -I{} test -L "/usr/lib/{}/libnss_pwb.so.2"'
     exit-status: 0


### PR DESCRIPTION
## Summary

- Creates build-time dangling symlinks from the glibc NSS multiarch paths to `/usr/lib/rstudio-server/bin/{jammy,noble}/libnss_pwb.so` — the location populated at runtime by `workbench-session-init`
- Appends `pwb` after `files` in `nsswitch.conf` for `passwd`, `group`, and `shadow` so rootless session users resolve via the Workbench API instead of failing a `/etc/passwd` lookup
- Handles both `amd64` (`x86_64-linux-gnu`) and `arm64` (`aarch64-linux-gnu`) via `TARGETARCH`

Dormant-safe: with no `workbench-nss.conf` present (or `WORKBENCH_NSS_CONFIG_PATH` unset), the module returns `UNAVAIL` and resolution falls through to `files` — non-rootless containers are unaffected.

Companion to rstudio/rstudio-docker-products#1053, extending the same pattern to both ubuntu2204 (jammy) and ubuntu2404 (noble).

## Test plan

- [ ] Build image: `bakery build --image-name workbench-session`
- [ ] Confirm symlink (jammy): `ls -la /usr/lib/x86_64-linux-gnu/libnss_pwb.so.2` → `../rstudio-server/bin/jammy/libnss_pwb.so`
- [ ] Confirm symlink (noble): `ls -la /usr/lib/x86_64-linux-gnu/libnss_pwb.so.2` → `../rstudio-server/bin/noble/libnss_pwb.so`
- [ ] Confirm nsswitch: `grep -E '^(passwd|group|shadow)' /etc/nsswitch.conf` shows `files pwb`
- [ ] Confirm graceful fallthrough (dangling symlink, no config): `getent passwd root` resolves without error
- [ ] Runtime test with init container populating the volume: `getent passwd <rootless-session-user>` resolves via pwb