### PR TITLE
Re-render: add uv self update before Python install

### DIFF
--- a/workbench-session/matrix/Containerfile.ubuntu2204
+++ b/workbench-session/matrix/Containerfile.ubuntu2204
@@ -6,7 +6,7 @@ ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
 
 ARG PYTHON_VERSION
-RUN uv python install $PYTHON_VERSION
+RUN uv self update && uv python install $PYTHON_VERSION
 RUN mv /opt/python/cpython-$PYTHON_VERSION-linux-*/ /opt/python/$PYTHON_VERSION
 
 

--- a/workbench-session/matrix/Containerfile.ubuntu2404
+++ b/workbench-session/matrix/Containerfile.ubuntu2404
@@ -6,7 +6,7 @@ ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
 
 ARG PYTHON_VERSION
-RUN uv python install $PYTHON_VERSION
+RUN uv self update && uv python install $PYTHON_VERSION
 RUN mv /opt/python/cpython-$PYTHON_VERSION-linux-*/ /opt/python/$PYTHON_VERSION
 
 

--- a/workbench/2025.09/Containerfile.ubuntu2204.std
+++ b/workbench/2025.09/Containerfile.ubuntu2204.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.13.7
+RUN uv self update && uv python install 3.13.7
 RUN mv /opt/python/cpython-3.13.7-linux-*/ /opt/python/3.13.7
 
 

--- a/workbench/2025.09/Containerfile.ubuntu2404.std
+++ b/workbench/2025.09/Containerfile.ubuntu2404.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.13.7
+RUN uv self update && uv python install 3.13.7
 RUN mv /opt/python/cpython-3.13.7-linux-*/ /opt/python/3.13.7
 
 

--- a/workbench/2026.01/Containerfile.ubuntu2204.std
+++ b/workbench/2026.01/Containerfile.ubuntu2204.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.14.2
+RUN uv self update && uv python install 3.14.2
 RUN mv /opt/python/cpython-3.14.2-linux-*/ /opt/python/3.14.2
 
 

--- a/workbench/2026.01/Containerfile.ubuntu2404.std
+++ b/workbench/2026.01/Containerfile.ubuntu2404.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.14.2
+RUN uv self update && uv python install 3.14.2
 RUN mv /opt/python/cpython-3.14.2-linux-*/ /opt/python/3.14.2
 
 

--- a/workbench/2026.04/Containerfile.ubuntu2204.std
+++ b/workbench/2026.04/Containerfile.ubuntu2204.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.14.4
+RUN uv self update && uv python install 3.14.4
 RUN mv /opt/python/cpython-3.14.4-linux-*/ /opt/python/3.14.4
 
 

--- a/workbench/2026.04/Containerfile.ubuntu2404.std
+++ b/workbench/2026.04/Containerfile.ubuntu2404.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.14.4
+RUN uv self update && uv python install 3.14.4
 RUN mv /opt/python/cpython-3.14.4-linux-*/ /opt/python/3.14.4
 
 

--- a/workbench/2026.05/Containerfile.ubuntu2204.std
+++ b/workbench/2026.05/Containerfile.ubuntu2204.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.14.5
+RUN uv self update && uv python install 3.14.5
 RUN mv /opt/python/cpython-3.14.5-linux-*/ /opt/python/3.14.5
 
 

--- a/workbench/2026.05/Containerfile.ubuntu2404.std
+++ b/workbench/2026.05/Containerfile.ubuntu2404.std
@@ -4,7 +4,7 @@ FROM ghcr.io/astral-sh/uv:debian-slim AS python-builder
 ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/python
 ENV UV_PYTHON_PREFERENCE=only-managed
-RUN uv python install 3.14.5
+RUN uv self update && uv python install 3.14.5
 RUN mv /opt/python/cpython-3.14.5-linux-*/ /opt/python/3.14.5
 
 


### PR DESCRIPTION
Applies `uv self update && uv python install` in all rendered Workbench and workbench-session Containerfiles, matching the pattern introduced in posit-dev/images-shared#597.