### PR TITLE
Restore daily dev version entry for workbench

### DIFF
--- a/bakery.yaml
+++ b/bakery.yaml
@@ -59,6 +59,20 @@ images:
     devVersions:
       - sourceType: stream
         product: workbench
+        channel: daily
+        os:
+          - name: Ubuntu 24.04
+            primary: true
+            platforms:
+              - linux/amd64
+              - linux/arm64
+          - name: Ubuntu 22.04
+        overrideRegistries:
+          - host: "ghcr.io"
+            namespace: "posit-dev"
+            repository: "workbench-preview"
+      - sourceType: stream
+        product: workbench
         channel: preview
         os:
           - name: Ubuntu 24.04


### PR DESCRIPTION
PR #131 and its follow-up commit (3eda0b0) together replaced the
`channel: daily` entry in `workbench`'s `devVersions` with `channel:
preview`, inadvertently dropping daily builds. The daily entry should
exist alongside the preview one — both push to
`ghcr.io/posit-dev/workbench-preview`.