### PR TITLE
Add preview stream devVersion to workbench-session-init

### DIFF
--- a/bakery.yaml
+++ b/bakery.yaml
@@ -153,6 +153,19 @@ images:
           - host: "ghcr.io"
             namespace: "posit-dev"
             repository: "workbench-session-init-preview"
+      - sourceType: stream
+        product: workbench-session
+        channel: preview
+        os:
+          - name: Ubuntu 24.04
+            primary: true
+            platforms:
+              - linux/amd64
+              - linux/arm64
+        overrideRegistries:
+          - host: "ghcr.io"
+            namespace: "posit-dev"
+            repository: "workbench-session-init-preview"
     versions:
       - name: 2026.05.0+218.pro1
         subpath: '2026.05'


### PR DESCRIPTION
\`workbench-session-init\` now tracks the \`preview\` channel in addition to \`daily\`, matching the pattern already in place for the \`workbench\` image. Pushes to \`workbench-session-init-preview\` on ghcr.io.