### PR TITLE
fix: extend timeouts for quarto tests

### DIFF
--- a/workbench-session/matrix/test/goss.yaml
+++ b/workbench-session/matrix/test/goss.yaml
@@ -55,13 +55,15 @@ command:
     stdout:
       - "{{ .Env.BUILD_ARG_PYTHON_VERSION }}"
   "Verify Quarto":
-    exec: /usr/local/bin/quarto check --quiet
+    exec: /usr/local/bin/quarto check
     exit-status: 0
+    timeout: 120000
   "Verify Quarto has TinyTeX installed":
     exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
       - "/tinytex\\s+Up to date/"
+    timeout: 120000
   "Verify TinyTeX is readable and executable by a non-root user":
     exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' nobody
     exit-status: 0

--- a/workbench-session/template/test/goss.yaml.jinja2
+++ b/workbench-session/template/test/goss.yaml.jinja2
@@ -62,13 +62,15 @@ command:
     stdout:
       - "{{ goss.build_arg_env_var("PYTHON_VERSION") }}"
   "Verify Quarto":
-    exec: /usr/local/bin/quarto check --quiet
+    exec: /usr/local/bin/quarto check
     exit-status: 0
+    timeout: 120000
   "Verify Quarto has TinyTeX installed":
     exec: "HOME='/opt' quarto list tools"
     exit-status: 0
     stderr:
       - "/tinytex\\s+Up to date/"
+    timeout: 120000
   "Verify TinyTeX is readable and executable by a non-root user":
     exec: su -s /bin/sh -c 'command -v tlmgr && command -v pdflatex && tlmgr --version && pdflatex --version' nobody
     exit-status: 0

--- a/workbench/2025.09/test/goss.yaml
+++ b/workbench/2025.09/test/goss.yaml
@@ -220,12 +220,13 @@ command:
     stdout:
       - "/usr/bin/openssl"
   "Verify Quarto":
-    exec: /usr/local/bin/quarto check --quiet
+    exec: /usr/local/bin/quarto check
     timeout: 120000
     exit-status: 0
   "Verify Quarto has TinyTeX installed":
     exec: "HOME='/opt' quarto list tools"
     exit-status: 0
+    timeout: 120000
     stderr:
       - "/tinytex\\s+Up to date/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}

--- a/workbench/2026.01/test/goss.yaml
+++ b/workbench/2026.01/test/goss.yaml
@@ -220,12 +220,13 @@ command:
     stdout:
       - "/usr/bin/openssl"
   "Verify Quarto":
-    exec: /usr/local/bin/quarto check --quiet
+    exec: /usr/local/bin/quarto check
     timeout: 120000
     exit-status: 0
   "Verify Quarto has TinyTeX installed":
     exec: "HOME='/opt' quarto list tools"
     exit-status: 0
+    timeout: 120000
     stderr:
       - "/tinytex\\s+Up to date/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}

--- a/workbench/2026.04/test/goss.yaml
+++ b/workbench/2026.04/test/goss.yaml
@@ -220,12 +220,13 @@ command:
     stdout:
       - "/usr/bin/openssl"
   "Verify Quarto":
-    exec: /usr/local/bin/quarto check --quiet
+    exec: /usr/local/bin/quarto check
     timeout: 120000
     exit-status: 0
   "Verify Quarto has TinyTeX installed":
     exec: "HOME='/opt' quarto list tools"
     exit-status: 0
+    timeout: 120000
     stderr:
       - "/tinytex\\s+Up to date/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}

--- a/workbench/2026.05/test/goss.yaml
+++ b/workbench/2026.05/test/goss.yaml
@@ -220,12 +220,13 @@ command:
     stdout:
       - "/usr/bin/openssl"
   "Verify Quarto":
-    exec: /usr/local/bin/quarto check --quiet
+    exec: /usr/local/bin/quarto check
     timeout: 120000
     exit-status: 0
   "Verify Quarto has TinyTeX installed":
     exec: "HOME='/opt' quarto list tools"
     exit-status: 0
+    timeout: 120000
     stderr:
       - "/tinytex\\s+Up to date/"
     skip: {{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}

--- a/workbench/template/test/goss.yaml.jinja2
+++ b/workbench/template/test/goss.yaml.jinja2
@@ -288,12 +288,13 @@ command:
     stdout:
       - "/usr/bin/openssl"
   "Verify Quarto":
-    exec: /usr/local/bin/quarto check --quiet
+    exec: /usr/local/bin/quarto check
     timeout: 120000
     exit-status: 0
   "Verify Quarto has TinyTeX installed":
     exec: "HOME='/opt' quarto list tools"
     exit-status: 0
+    timeout: 120000
     stderr:
       - "/tinytex\\s+Up to date/"
     skip: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Minimal" }}true{{ else }}false{{ end }}{% endraw %}


### PR DESCRIPTION
Resolves failures from https://github.com/posit-dev/images-workbench/actions/runs/27380120374

- extend timeouts for `quarto check` to 120s
- remove `--quiet` flag from `quarto check` for debugging