### PR TITLE
Suppress Quarto TinyTeX progress spam in builds (CI=true)

### DIFF
--- a/workbench-session/matrix/Containerfile.ubuntu2204
+++ b/workbench-session/matrix/Containerfile.ubuntu2204
@@ -111,7 +111,7 @@ RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 COPY workbench-session/matrix/conf/vscode.extensions.conf /etc/rstudio/vscode.extensions.conf

--- a/workbench-session/matrix/Containerfile.ubuntu2404
+++ b/workbench-session/matrix/Containerfile.ubuntu2404
@@ -111,7 +111,7 @@ RUN bash -c "$(curl -1fsSL 'https://dl.posit.co/public/open/setup.deb.sh')" && \
 # HOME="/opt" workaround: https://github.com/quarto-dev/quarto-cli/issues/11800
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /opt/quarto/bin/quarto install tinytex --no-prompt --update-path && \
     rm -f /tmp/tinytex-release.json
 
 COPY workbench-session/matrix/conf/vscode.extensions.conf /etc/rstudio/vscode.extensions.conf

--- a/workbench/2025.09/Containerfile.ubuntu2204.std
+++ b/workbench/2025.09/Containerfile.ubuntu2204.std
@@ -130,7 +130,7 @@ RUN mkdir -p /var/lib/rstudio-server/monitor/log \
 # for TinyTeX, see https://github.com/quarto-dev/quarto-cli/issues/11800.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --update-path \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --update-path \
     && rm -f /tmp/tinytex-release.json
 
 EXPOSE 8787/tcp

--- a/workbench/2025.09/Containerfile.ubuntu2404.std
+++ b/workbench/2025.09/Containerfile.ubuntu2404.std
@@ -130,7 +130,7 @@ RUN mkdir -p /var/lib/rstudio-server/monitor/log \
 # for TinyTeX, see https://github.com/quarto-dev/quarto-cli/issues/11800.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --update-path \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --update-path \
     && rm -f /tmp/tinytex-release.json
 
 EXPOSE 8787/tcp

--- a/workbench/2026.01/Containerfile.ubuntu2204.std
+++ b/workbench/2026.01/Containerfile.ubuntu2204.std
@@ -130,7 +130,7 @@ RUN mkdir -p /var/lib/rstudio-server/monitor/log \
 # for TinyTeX, see https://github.com/quarto-dev/quarto-cli/issues/11800.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --update-path \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --update-path \
     && rm -f /tmp/tinytex-release.json
 
 EXPOSE 8787/tcp

--- a/workbench/2026.01/Containerfile.ubuntu2404.std
+++ b/workbench/2026.01/Containerfile.ubuntu2404.std
@@ -130,7 +130,7 @@ RUN mkdir -p /var/lib/rstudio-server/monitor/log \
 # for TinyTeX, see https://github.com/quarto-dev/quarto-cli/issues/11800.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --update-path \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --update-path \
     && rm -f /tmp/tinytex-release.json
 
 EXPOSE 8787/tcp

--- a/workbench/2026.04/Containerfile.ubuntu2204.std
+++ b/workbench/2026.04/Containerfile.ubuntu2204.std
@@ -124,7 +124,7 @@ RUN mkdir -p /var/lib/rstudio-server/monitor/log \
 # the cache on new releases.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --update-path \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --update-path \
     && rm -f /tmp/tinytex-release.json
 
 EXPOSE 8787/tcp

--- a/workbench/2026.04/Containerfile.ubuntu2404.std
+++ b/workbench/2026.04/Containerfile.ubuntu2404.std
@@ -124,7 +124,7 @@ RUN mkdir -p /var/lib/rstudio-server/monitor/log \
 # the cache on new releases.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --update-path \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --update-path \
     && rm -f /tmp/tinytex-release.json
 
 EXPOSE 8787/tcp

--- a/workbench/2026.05/Containerfile.ubuntu2204.std
+++ b/workbench/2026.05/Containerfile.ubuntu2204.std
@@ -131,7 +131,7 @@ RUN mkdir -p /var/lib/rstudio-server/monitor/log \
 # for TinyTeX, see https://github.com/quarto-dev/quarto-cli/issues/11800.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --update-path \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --update-path \
     && rm -f /tmp/tinytex-release.json
 
 EXPOSE 8787/tcp

--- a/workbench/2026.05/Containerfile.ubuntu2404.std
+++ b/workbench/2026.05/Containerfile.ubuntu2404.std
@@ -131,7 +131,7 @@ RUN mkdir -p /var/lib/rstudio-server/monitor/log \
 # for TinyTeX, see https://github.com/quarto-dev/quarto-cli/issues/11800.
 ADD https://github.com/rstudio/tinytex-releases/releases/latest /tmp/tinytex-release.json
 RUN --mount=type=secret,id=github_token,required=false \
-    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --update-path \
+    GH_TOKEN="$([ -s /run/secrets/github_token ] && cat /run/secrets/github_token)" HOME="/opt" CI=true /lib/rstudio-server/bin/quarto/bin/quarto install tinytex --no-prompt --update-path \
     && rm -f /tmp/tinytex-release.json
 
 EXPOSE 8787/tcp


### PR DESCRIPTION
Quarto renders an animated TinyTeX download progress bar unless `runningInCI()` passes. The env vars it checks (`CI`, `GITHUB_ACTIONS`, …) do not reach a `docker build` RUN step, so Quarto redraws the bar on every download tick — one Workbench dev build emitted ~26,000 lines (~5 MB, 68% of the log), slowing the build and bloating CI logs.

Setting `CI=true` inline on the install command collapses the progress bar to a single line while keeping error output (unlike `--quiet`). The fix lives in the shared bakery macro; this adds it directly to the committed Containerfiles so builds get it without waiting for a re-render.

- https://github.com/posit-dev/images-shared/pull/627