### PR TITLE
Temporarily disable `daily` builds.

### DIFF
--- a/bakery.yaml
+++ b/bakery.yaml
@@ -57,20 +57,21 @@ images:
         extension: min
         tagDisplayName: min
     devVersions:
-      - sourceType: stream
-        product: workbench
-        channel: daily
-        os:
-          - name: Ubuntu 24.04
-            primary: true
-            platforms:
-              - linux/amd64
-              - linux/arm64
-          - name: Ubuntu 22.04
-        overrideRegistries:
-          - host: "ghcr.io"
-            namespace: "posit-dev"
-            repository: "workbench-preview"
+      # Dailies temporarily disabled. See https://github.com/posit-dev/images-shared/issues/632
+      # - sourceType: stream
+      #   product: workbench
+      #   channel: daily
+      #   os:
+      #     - name: Ubuntu 24.04
+      #       primary: true
+      #       platforms:
+      #         - linux/amd64
+      #         - linux/arm64
+      #     - name: Ubuntu 22.04
+      #   overrideRegistries:
+      #     - host: "ghcr.io"
+      #       namespace: "posit-dev"
+      #       repository: "workbench-preview"
       - sourceType: stream
         product: workbench
         channel: preview
@@ -139,20 +140,21 @@ images:
       - tool: soci
         enabled: true
     devVersions:
-      - sourceType: stream
-        product: workbench-session
-        channel: daily
-        # Runtime binary is arch-specific, not OS-specific; Ubuntu 24.04 only.
-        os:
-          - name: Ubuntu 24.04
-            primary: true
-            platforms:
-              - linux/amd64
-              - linux/arm64
-        overrideRegistries:
-          - host: "ghcr.io"
-            namespace: "posit-dev"
-            repository: "workbench-session-init-preview"
+      # Dailies temporarily disabled. See https://github.com/posit-dev/images-shared/issues/632
+      # - sourceType: stream
+      #   product: workbench-session
+      #   channel: daily
+      #   # Runtime binary is arch-specific, not OS-specific; Ubuntu 24.04 only.
+      #   os:
+      #     - name: Ubuntu 24.04
+      #       primary: true
+      #       platforms:
+      #         - linux/amd64
+      #         - linux/arm64
+      #   overrideRegistries:
+      #     - host: "ghcr.io"
+      #       namespace: "posit-dev"
+      #       repository: "workbench-session-init-preview"
       - sourceType: stream
         product: workbench-session
         channel: preview


### PR DESCRIPTION
The daily and preview builds were both resolving to version `2026.06.0+242.pro1` which was leading to a collision in builds, tags, and merging manifests.

Temporarily disabling this.
