### PR TITLE
Test bakery branch: dgoss stderr visibility fix

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,6 +57,7 @@ jobs:
       packages: write
     uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
     with:
+      version: "worktree-dgoss-docker-exit-handling"
       dev-versions: "exclude"
       matrix-versions: "exclude"
 
@@ -67,6 +68,7 @@ jobs:
       packages: write
     uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
     with:
+      version: "worktree-dgoss-docker-exit-handling"
       dev-versions: "only"
       matrix-versions: "include"
 
@@ -77,6 +79,7 @@ jobs:
       packages: write
     uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
     with:
+      version: "worktree-dgoss-docker-exit-handling"
       matrix-versions: "only"
 
   zizmor:


### PR DESCRIPTION
Draft PR to exercise the bakery changes on `worktree-dgoss-docker-exit-handling` in images-shared before that branch is merged.

The `pr.yml` workflow installs bakery from that branch so CI runs against the dgoss stderr fix (https://github.com/posit-dev/images-shared/pull/new/worktree-dgoss-docker-exit-handling).

Do not merge. Revert `pr.yml` to `version: main` (or remove the `version:` line) once the images-shared branch lands.