### PR TITLE
Increase goss wait to 30s

### DIFF
--- a/bakery.yaml
+++ b/bakery.yaml
@@ -51,7 +51,7 @@ images:
         primary: true
         options:
           - tool: goss
-            wait: 15
+            wait: 30
             command: "/usr/bin/supervisord -c /etc/supervisor/supervisord.conf"
       - name: Minimal
         extension: min


### PR DESCRIPTION
Tests were failing waiting for port 8787. Increase the wait to work
around this.
