### PR TITLE
fix: temporary image cleanup race condition

### DIFF
--- a/.github/workflows/development-positron.yml
+++ b/.github/workflows/development-positron.yml
@@ -83,11 +83,11 @@ jobs:
       contents: read
       packages: write
     needs:
-      - dev
+      - ci
 
     uses: "posit-dev/images-shared/.github/workflows/clean.yml@main"
     with:
       dev-versions: "only"
       remove-dangling-caches: true
       remove-caches-older-than: 14
-      remove-dangling-temporary-images: true
+      remove-temporary-images-older-than: 2

--- a/.github/workflows/development-workbench.yml
+++ b/.github/workflows/development-workbench.yml
@@ -90,11 +90,11 @@ jobs:
       contents: read
       packages: write
     needs:
-      - dev
+      - ci
 
     uses: "posit-dev/images-shared/.github/workflows/clean.yml@main"
     with:
       dev-versions: "only"
       remove-dangling-caches: true
       remove-caches-older-than: 14
-      remove-dangling-temporary-images: true
+      remove-temporary-images-older-than: 2

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -71,10 +71,10 @@ jobs:
       contents: read
       packages: write
     needs:
-      - build
+      - ci
 
     uses: "posit-dev/images-shared/.github/workflows/clean.yml@main"
     with:
       remove-dangling-caches: true
       remove-caches-older-than: 14
-      remove-dangling-temporary-images: true
+      remove-temporary-images-older-than: 2

--- a/.github/workflows/session.yml
+++ b/.github/workflows/session.yml
@@ -68,11 +68,11 @@ jobs:
       contents: read
       packages: write
     needs:
-      - build
+      - ci
 
     uses: "posit-dev/images-shared/.github/workflows/clean.yml@main"
     with:
       matrix-versions: "only"
       remove-dangling-caches: true
       remove-caches-older-than: 14
-      remove-dangling-temporary-images: true
+      remove-temporary-images-older-than: 2


### PR DESCRIPTION
Potential fix to failures in https://github.com/posit-dev/images-workbench/actions/runs/28394320735

- Remove `remove-dangling-temporary-images: true` as it could remove temporary artifacts in use
- Add `remove-temporary-images-older-than: 2` to remove temporary artifacts push >=2days prior
- Make clean dependent on CI job rather than build job