### PR TITLE
Promote rstudio-server rootless plumbing to 2026.06+ releases

### DIFF
--- a/workbench/2026.06/Containerfile.ubuntu2204.min
+++ b/workbench/2026.06/Containerfile.ubuntu2204.min
@@ -20,6 +20,10 @@ ENV PWB_DIAGNOSTIC_DIR=/var/log/rstudio
 ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
 
+### Pre-create rstudio-server user (uid/gid 999) before any installs ###
+COPY --chmod=0755 workbench/scripts/precreate_rstudio_user.sh /tmp/precreate_rstudio_user.sh
+RUN /tmp/precreate_rstudio_user.sh && \
+    rm -f /tmp/precreate_rstudio_user.sh
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
@@ -68,7 +72,21 @@ COPY "workbench/2026.06/conf/jupyter/*" "workbench/2026.06/conf/launcher/*" "wor
 
 ### Configure Workbench ###
 RUN mkdir -p /var/lib/rstudio-server/monitor/log \
-    && chown -R rstudio-server:rstudio-server /var/lib/rstudio-server/monitor \
+               /var/lib/rstudio-server/conf \
+               /var/lib/rstudio-server/body \
+               /var/lib/rstudio-server/proxy \
+               /var/lib/rstudio-launcher \
+               /var/log/rstudio \
+               /var/run/supervisor \
+    && chown -R rstudio-server:rstudio-server \
+        /var/lib/rstudio-server \
+        /var/lib/rstudio-launcher \
+        /var/log/rstudio \
+        /var/run/supervisor \
+    && chmod -R g+w /var/lib/rstudio-server /var/lib/rstudio-launcher /var/log/rstudio /var/run/supervisor \
+    && find /var/lib/rstudio-server /var/lib/rstudio-launcher /var/log/rstudio /var/run/supervisor -type d -exec chmod g+s {} + \
+    && mkdir -p /var/run/rstudio-server \
+    && chmod 1777 /var/run/rstudio-server \
     && mkdir -p /startup/custom/ \
     && mkdir -p /startup/user-provisioning/ \
     && printf '\n# allow home directory creation\nsession required pam_mkhomedir.so skel=/etc/skel umask=0077\n' >> /etc/pam.d/common-session \

--- a/workbench/2026.06/Containerfile.ubuntu2204.std
+++ b/workbench/2026.06/Containerfile.ubuntu2204.std
@@ -29,7 +29,12 @@ ENV PWB_LAUNCHER_TIMEOUT=10
 ENV PWB_DIAGNOSTIC_DIR=/var/log/rstudio
 ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
+ENV PWB_SSSD=true
 
+### Pre-create rstudio-server user (uid/gid 999) before any installs ###
+COPY --chmod=0755 workbench/scripts/precreate_rstudio_user.sh /tmp/precreate_rstudio_user.sh
+RUN /tmp/precreate_rstudio_user.sh && \
+    rm -f /tmp/precreate_rstudio_user.sh
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
@@ -104,16 +109,31 @@ RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Copy startup scripts ###
 COPY --chmod=0775 "workbench/2026.06/scripts/startup.sh" /usr/local/bin/startup.sh
+COPY --chmod=0755 workbench/scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY "workbench/2026.06/startup/launcher" /startup/launcher
 COPY "workbench/2026.06/startup/base" /startup/base
 COPY "workbench/2026.06/startup/supervisord.conf" /etc/supervisor/supervisord.conf
-COPY "workbench/2026.06/startup/user-provisioning" /startup/user-provisioning
 COPY --chmod=600 "workbench/2026.06/conf/sssd/sssd.conf" /etc/sssd/sssd.conf
+COPY "workbench/2026.06/startup/user-provisioning/sssd.conf" /opt/startup-templates/sssd.conf
 COPY "workbench/2026.06/conf/jupyter/*" "workbench/2026.06/conf/launcher/*" "workbench/2026.06/conf/rstudio/*" "workbench/2026.06/conf/positron/*" "workbench/2026.06/conf/vscode/*" /etc/rstudio/
 
 ### Configure Workbench ###
 RUN mkdir -p /var/lib/rstudio-server/monitor/log \
-    && chown -R rstudio-server:rstudio-server /var/lib/rstudio-server/monitor \
+               /var/lib/rstudio-server/conf \
+               /var/lib/rstudio-server/body \
+               /var/lib/rstudio-server/proxy \
+               /var/lib/rstudio-launcher \
+               /var/log/rstudio \
+               /var/run/supervisor \
+    && chown -R rstudio-server:rstudio-server \
+        /var/lib/rstudio-server \
+        /var/lib/rstudio-launcher \
+        /var/log/rstudio \
+        /var/run/supervisor \
+    && chmod -R g+w /var/lib/rstudio-server /var/lib/rstudio-launcher /var/log/rstudio /var/run/supervisor \
+    && find /var/lib/rstudio-server /var/lib/rstudio-launcher /var/log/rstudio /var/run/supervisor -type d -exec chmod g+s {} + \
+    && mkdir -p /var/run/rstudio-server \
+    && chmod 1777 /var/run/rstudio-server \
     && mkdir -p /startup/custom/ \
     && mkdir -p /startup/user-provisioning/ \
     && printf '\n# allow home directory creation\nsession required pam_mkhomedir.so skel=/etc/skel umask=0077\n' >> /etc/pam.d/common-session \
@@ -138,4 +158,5 @@ EXPOSE 8787/tcp
 EXPOSE 5559/tcp
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
     CMD curl -fsS http://localhost:8787/health-check || exit 1
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/workbench/2026.06/Containerfile.ubuntu2404.min
+++ b/workbench/2026.06/Containerfile.ubuntu2404.min
@@ -22,6 +22,10 @@ ENV PWB_EXIT_AFTER_VERIFY=false
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+### Pre-create rstudio-server user (uid/gid 999) before any installs ###
+COPY --chmod=0755 workbench/scripts/precreate_rstudio_user.sh /tmp/precreate_rstudio_user.sh
+RUN /tmp/precreate_rstudio_user.sh && \
+    rm -f /tmp/precreate_rstudio_user.sh
 
 ### Setup environment ###
 RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
@@ -68,7 +72,21 @@ COPY "workbench/2026.06/conf/jupyter/*" "workbench/2026.06/conf/launcher/*" "wor
 
 ### Configure Workbench ###
 RUN mkdir -p /var/lib/rstudio-server/monitor/log \
-    && chown -R rstudio-server:rstudio-server /var/lib/rstudio-server/monitor \
+               /var/lib/rstudio-server/conf \
+               /var/lib/rstudio-server/body \
+               /var/lib/rstudio-server/proxy \
+               /var/lib/rstudio-launcher \
+               /var/log/rstudio \
+               /var/run/supervisor \
+    && chown -R rstudio-server:rstudio-server \
+        /var/lib/rstudio-server \
+        /var/lib/rstudio-launcher \
+        /var/log/rstudio \
+        /var/run/supervisor \
+    && chmod -R g+w /var/lib/rstudio-server /var/lib/rstudio-launcher /var/log/rstudio /var/run/supervisor \
+    && find /var/lib/rstudio-server /var/lib/rstudio-launcher /var/log/rstudio /var/run/supervisor -type d -exec chmod g+s {} + \
+    && mkdir -p /var/run/rstudio-server \
+    && chmod 1777 /var/run/rstudio-server \
     && mkdir -p /startup/custom/ \
     && mkdir -p /startup/user-provisioning/ \
     && printf '\n# allow home directory creation\nsession required pam_mkhomedir.so skel=/etc/skel umask=0077\n' >> /etc/pam.d/common-session \

--- a/workbench/2026.06/Containerfile.ubuntu2404.std
+++ b/workbench/2026.06/Containerfile.ubuntu2404.std
@@ -29,9 +29,14 @@ ENV PWB_LAUNCHER_TIMEOUT=10
 ENV PWB_DIAGNOSTIC_DIR=/var/log/rstudio
 ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
+ENV PWB_SSSD=true
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+### Pre-create rstudio-server user (uid/gid 999) before any installs ###
+COPY --chmod=0755 workbench/scripts/precreate_rstudio_user.sh /tmp/precreate_rstudio_user.sh
+RUN /tmp/precreate_rstudio_user.sh && \
+    rm -f /tmp/precreate_rstudio_user.sh
 
 ### Setup environment ###
 RUN echo 'Acquire::Retries "3"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' > /etc/apt/apt.conf.d/99-retries && \
@@ -104,16 +109,31 @@ RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Copy startup scripts ###
 COPY --chmod=0775 "workbench/2026.06/scripts/startup.sh" /usr/local/bin/startup.sh
+COPY --chmod=0755 workbench/scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY "workbench/2026.06/startup/launcher" /startup/launcher
 COPY "workbench/2026.06/startup/base" /startup/base
 COPY "workbench/2026.06/startup/supervisord.conf" /etc/supervisor/supervisord.conf
-COPY "workbench/2026.06/startup/user-provisioning" /startup/user-provisioning
 COPY --chmod=600 "workbench/2026.06/conf/sssd/sssd.conf" /etc/sssd/sssd.conf
+COPY "workbench/2026.06/startup/user-provisioning/sssd.conf" /opt/startup-templates/sssd.conf
 COPY "workbench/2026.06/conf/jupyter/*" "workbench/2026.06/conf/launcher/*" "workbench/2026.06/conf/rstudio/*" "workbench/2026.06/conf/positron/*" "workbench/2026.06/conf/vscode/*" /etc/rstudio/
 
 ### Configure Workbench ###
 RUN mkdir -p /var/lib/rstudio-server/monitor/log \
-    && chown -R rstudio-server:rstudio-server /var/lib/rstudio-server/monitor \
+               /var/lib/rstudio-server/conf \
+               /var/lib/rstudio-server/body \
+               /var/lib/rstudio-server/proxy \
+               /var/lib/rstudio-launcher \
+               /var/log/rstudio \
+               /var/run/supervisor \
+    && chown -R rstudio-server:rstudio-server \
+        /var/lib/rstudio-server \
+        /var/lib/rstudio-launcher \
+        /var/log/rstudio \
+        /var/run/supervisor \
+    && chmod -R g+w /var/lib/rstudio-server /var/lib/rstudio-launcher /var/log/rstudio /var/run/supervisor \
+    && find /var/lib/rstudio-server /var/lib/rstudio-launcher /var/log/rstudio /var/run/supervisor -type d -exec chmod g+s {} + \
+    && mkdir -p /var/run/rstudio-server \
+    && chmod 1777 /var/run/rstudio-server \
     && mkdir -p /startup/custom/ \
     && mkdir -p /startup/user-provisioning/ \
     && printf '\n# allow home directory creation\nsession required pam_mkhomedir.so skel=/etc/skel umask=0077\n' >> /etc/pam.d/common-session \
@@ -138,4 +158,5 @@ EXPOSE 8787/tcp
 EXPOSE 5559/tcp
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
     CMD curl -fsS http://localhost:8787/health-check || exit 1
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/workbench/2026.06/startup/supervisord.conf
+++ b/workbench/2026.06/startup/supervisord.conf
@@ -1,13 +1,12 @@
 ; supervisor config file
 
 [unix_http_server]
-file=/var/run/supervisor.sock   ; (the path to the socket file)
+file=/var/run/supervisor/supervisor.sock   ; (the path to the socket file)
 chmod=0700                       ; sockef file mode (default 0700)
 
 [supervisord]
 logfile=/dev/stdout ; (main log file;default $CWD/supervisord.log)
-user=root
-pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
+pidfile=/var/run/supervisor/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
 ; should configure each program to use stdout/stderr
 ; childlogdir=/var/log/supervisor            ; ('AUTO' child log dir, default $TEMP)
 logfile_maxbytes=0
@@ -22,7 +21,7 @@ nodaemon=true
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [supervisorctl]
-serverurl=unix:///var/run/supervisor.sock ; use a unix:// URL  for a unix socket
+serverurl=unix:///var/run/supervisor/supervisor.sock ; use a unix:// URL  for a unix socket
 
 ; The [include] section can just contain the "files" setting.  This
 ; setting can list multiple files (separated by whitespace or

--- a/workbench/2026.06/test/goss.yaml
+++ b/workbench/2026.06/test/goss.yaml
@@ -2,14 +2,14 @@ user:
   rstudio-server:
     exists: true
     uid: 999
-    gid: {{ if and (eq .Env.IMAGE_VARIANT "Standard") (and (eq .Env.IMAGE_OS_NAME "ubuntu") (eq .Env.IMAGE_OS_VERSION "24.04")) }}997{{ else }}999{{ end }}
+    gid: 999
     groups:
       - rstudio-server
 
 group:
   rstudio-server:
     exists: true
-    gid: {{ if and (eq .Env.IMAGE_VARIANT "Standard") (and (eq .Env.IMAGE_OS_NAME "ubuntu") (eq .Env.IMAGE_OS_VERSION "24.04")) }}997{{ else }}999{{ end }}
+    gid: 999
 
 package:
   rstudio-server:
@@ -74,11 +74,55 @@ file:
   # Check for rstudio-launcher executable
   /usr/lib/rstudio-server/bin/rstudio-launcher:
     exists: true
-  # Check for rstudio-server monitor log directory
+  # Check for rstudio-server runtime directories with correct ownership and setgid
+  /var/lib/rstudio-server:
+    exists: true
+    owner: rstudio-server
+    group: rstudio-server
+    gid: 999
+    mode: "2775"
   /var/lib/rstudio-server/monitor/log:
     exists: true
     owner: rstudio-server
     group: rstudio-server
+    gid: 999
+  /var/lib/rstudio-server/conf:
+    exists: true
+    owner: rstudio-server
+    group: rstudio-server
+    gid: 999
+  /var/lib/rstudio-server/body:
+    exists: true
+    owner: rstudio-server
+    group: rstudio-server
+    gid: 999
+  /var/lib/rstudio-server/proxy:
+    exists: true
+    owner: rstudio-server
+    group: rstudio-server
+    gid: 999
+  # rstudio-launcher resets its scratch directory to 0755 on startup, so we
+  # only assert ownership here; the build-time setgid mode does not survive.
+  /var/lib/rstudio-launcher:
+    exists: true
+    owner: rstudio-server
+    group: rstudio-server
+    gid: 999
+  /var/log/rstudio:
+    exists: true
+    owner: rstudio-server
+    group: rstudio-server
+    gid: 999
+    mode: "2775"
+  /var/run/rstudio-server:
+    exists: true
+    mode: "1777"
+  /var/run/supervisor:
+    exists: true
+    owner: rstudio-server
+    group: rstudio-server
+    gid: 999
+    mode: "2775"
   # Check for code-server executable (path varies based on RStudio Workbench version)
   {{ $version_split := split "." "2026.06.0+242.pro13" }}
   {{ if or (ge ($version_split._0 | atoi) 2025) (and (ge ($version_split._0 | atoi) 2024) (ge ($version_split._1 | atoi) 7)) }}
@@ -104,6 +148,14 @@ file:
     owner: root
     group: root
     mode: "0600"
+  # sssd supervisord program is staged here; entrypoint installs it at runtime when root
+  /opt/startup-templates/sssd.conf:
+    exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
+    contains:
+      - "/^\\[program:sssd\\]$/"
+  /usr/local/bin/entrypoint.sh:
+    exists: {{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}
+    mode: "0755"
   # Check for repos.conf
   /etc/rstudio/repos.conf:
     exists: true
@@ -179,7 +231,7 @@ file:
 
 command:
   "Ensure rstudio-server has permissions to log directory":
-    exec: su rstudio-server -c 'touch /var/lib/rstudio-server/monitor/log/rstudio-server.log'
+    exec: sudo -u rstudio-server touch /var/lib/rstudio-server/monitor/log/rstudio-server.log
     exit-status: 0
   "Ensure server log can be created":
     exec: touch /var/log/rstudio-server.log

--- a/workbench/README.md
+++ b/workbench/README.md
@@ -147,6 +147,7 @@ Posit publishes Workbench images for `linux/amd64` only. `linux/arm64` builds re
 | `PWB_TESTUSER`         | Test user name. If empty, the image creates no test user.                                                                                       |
 | `PWB_TESTUSER_PASSWD`  | Test user password                                                                                                                              |
 | `PWB_TESTUSER_UID`     | Test user UID (default: `10000` when `PWB_TESTUSER` is set)                                                                                     |
+| `PWB_SSSD`             | Enable `sssd` for user provisioning (default: `true`). Set to `false` to disable `sssd`.                                                        |
 | `PWB_STARTUP_DEBUG`    | Set to `1` for verbose startup logging                                                                                                          |
 | `PWB_DIAGNOSTIC_ENABLE`| When true, run `rstudio-server verify-installation` before server start and write results to `$PWB_DIAGNOSTIC_DIR/verify.log` (default: `false`) |
 | `PWB_DIAGNOSTIC_DIR`   | Directory for diagnostic logs (default: `/var/log/rstudio`)                                                                                     |
@@ -266,6 +267,8 @@ docker run -d \
 
 For custom authentication or session behavior with PAM, you might also need to modify the PAM configuration files in the container. See the [Workbench admin guide](https://docs.posit.co/ide/server-pro/admin/authenticating_users/authenticating_users.html) for more information.
 
+To disable `sssd` entirely, set `PWB_SSSD=false`. `sssd` requires root, so it is also skipped automatically when the container runs as a non-root user.
+
 ### Custom configuration
 
 Mount a custom configuration directory or file:
@@ -314,7 +317,7 @@ The image manages these services:
 
 - **Workbench**: the main server process. The startup configuration mounts at `/startup/base`.
 - **Job Launcher**: enables Positron, RStudio, JupyterLab, and VS Code sessions, as well as integration with job schedulers like Slurm and Kubernetes. Enabled by default. The startup configuration mounts at `/startup/launcher`. To disable, mount an empty volume over `/startup/launcher`.
-- **sssd**: provides user provisioning when connected to an LDAP directory or other user store. Enabled by default with a placeholder domain that does nothing. To use your own directory, mount required `.conf` files into `/etc/sssd/conf.d/` (see [User provisioning](#user-provisioning)). To disable entirely, mount an empty volume over `/startup/user-provisioning/`.
+- **sssd**: provides user provisioning when connected to an LDAP directory or other user store. Enabled by default with a placeholder domain that does nothing. To use your own directory, mount required `.conf` files into `/etc/sssd/conf.d/` (see [User provisioning](#user-provisioning)). To disable entirely, set `PWB_SSSD=false` or mount an empty volume over `/startup/user-provisioning/`.
 - **custom**: to run additional services inside the container, mount supervisord configuration files into `/startup/custom/`. `supervisord` starts and manages them alongside the built-in services. In Kubernetes, `initContainers` or sidecar containers are often a better fit.
 
 ## User

--- a/workbench/template/Containerfile.ubuntu2204.jinja2
+++ b/workbench/template/Containerfile.ubuntu2204.jinja2
@@ -6,6 +6,10 @@ Bakery handles bootstrapping the files into template rendering.
 {%- import "python.j2" as python -%}
 {%- import "quarto.j2" as quarto -%}
 {%- import "r.j2" as r -%}
+{%- set version_parts = Image.Version.split('.') -%}
+{%- set rootless_support = Image.IsDevelopmentVersion
+    or (version_parts[0] | int > 2026)
+    or (version_parts[0] | int == 2026 and version_parts[1] | int >= 6) -%}
 {%- if Image.Variant != "Minimal" -%}
 # Build Python using uv in a separate stage
 {{ python.build_stage(Dependencies.python) }}
@@ -33,10 +37,10 @@ ENV PWB_LAUNCHER_TIMEOUT=10
 ENV PWB_DIAGNOSTIC_DIR=/var/log/rstudio
 ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
-{%- if Image.IsDevelopmentVersion and Image.Variant != "Minimal" %}
+{%- if rootless_support and Image.Variant != "Minimal" %}
 ENV PWB_SSSD=true
 {%- endif %}
-{% if Image.IsDevelopmentVersion %}
+{% if rootless_support %}
 ### Pre-create rstudio-server user (uid/gid 999) before any installs ###
 COPY --chmod=0755 {{ Path.Image }}/scripts/precreate_rstudio_user.sh /tmp/precreate_rstudio_user.sh
 RUN /tmp/precreate_rstudio_user.sh && \
@@ -94,18 +98,18 @@ RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Copy startup scripts ###
 COPY --chmod=0775 "{{ Path.Version }}/scripts/startup.sh" /usr/local/bin/startup.sh
-{%- if Image.IsDevelopmentVersion and Image.Variant != "Minimal" %}
+{%- if rootless_support and Image.Variant != "Minimal" %}
 COPY --chmod=0755 {{ Path.Image }}/scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
 {%- endif %}
 COPY "{{ Path.Version }}/startup/launcher" /startup/launcher
 COPY "{{ Path.Version }}/startup/base" /startup/base
 COPY "{{ Path.Version }}/startup/supervisord.conf" /etc/supervisor/supervisord.conf
 {%- if Image.Variant != "Minimal" %}
-{%- if not Image.IsDevelopmentVersion %}
+{%- if not rootless_support %}
 COPY "{{ Path.Version }}/startup/user-provisioning" /startup/user-provisioning
 {%- endif %}
 COPY --chmod=600 "{{ Path.Version }}/conf/sssd/sssd.conf" /etc/sssd/sssd.conf
-{%- if Image.IsDevelopmentVersion %}
+{%- if rootless_support %}
 COPY "{{ Path.Version }}/startup/user-provisioning/sssd.conf" /opt/startup-templates/sssd.conf
 {%- endif %}
 {%- endif %}
@@ -113,7 +117,7 @@ COPY "{{ Path.Version }}/conf/jupyter/*" "{{ Path.Version }}/conf/launcher/*" "{
 
 ### Configure Workbench ###
 RUN mkdir -p /var/lib/rstudio-server/monitor/log \
-{%- if Image.IsDevelopmentVersion %}
+{%- if rootless_support %}
                /var/lib/rstudio-server/conf \
                /var/lib/rstudio-server/body \
                /var/lib/rstudio-server/proxy \
@@ -159,7 +163,7 @@ EXPOSE 8787/tcp
 EXPOSE 5559/tcp
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
     CMD curl -fsS http://localhost:8787/health-check || exit 1
-{%- if Image.IsDevelopmentVersion and Image.Variant != "Minimal" %}
+{%- if rootless_support and Image.Variant != "Minimal" %}
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 {%- endif %}
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/workbench/template/Containerfile.ubuntu2404.jinja2
+++ b/workbench/template/Containerfile.ubuntu2404.jinja2
@@ -6,6 +6,10 @@ Bakery handles bootstrapping the files into template rendering.
 {%- import "python.j2" as python -%}
 {%- import "quarto.j2" as quarto -%}
 {%- import "r.j2" as r -%}
+{%- set version_parts = Image.Version.split('.') -%}
+{%- set rootless_support = Image.IsDevelopmentVersion
+    or (version_parts[0] | int > 2026)
+    or (version_parts[0] | int == 2026 and version_parts[1] | int >= 6) -%}
 {%- if Image.Variant != "Minimal" -%}
 # Build Python using uv in a separate stage
 {{ python.build_stage(Dependencies.python) }}
@@ -33,13 +37,13 @@ ENV PWB_LAUNCHER_TIMEOUT=10
 ENV PWB_DIAGNOSTIC_DIR=/var/log/rstudio
 ENV PWB_DIAGNOSTIC_ENABLE=false
 ENV PWB_EXIT_AFTER_VERIFY=false
-{%- if Image.IsDevelopmentVersion and Image.Variant != "Minimal" %}
+{%- if rootless_support and Image.Variant != "Minimal" %}
 ENV PWB_SSSD=true
 {%- endif %}
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
-{% if Image.IsDevelopmentVersion -%}
+{% if rootless_support -%}
 ### Pre-create rstudio-server user (uid/gid 999) before any installs ###
 COPY --chmod=0755 {{ Path.Image }}/scripts/precreate_rstudio_user.sh /tmp/precreate_rstudio_user.sh
 RUN /tmp/precreate_rstudio_user.sh && \
@@ -94,18 +98,18 @@ RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
 
 ### Copy startup scripts ###
 COPY --chmod=0775 "{{ Path.Version }}/scripts/startup.sh" /usr/local/bin/startup.sh
-{%- if Image.IsDevelopmentVersion and Image.Variant != "Minimal" %}
+{%- if rootless_support and Image.Variant != "Minimal" %}
 COPY --chmod=0755 {{ Path.Image }}/scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
 {%- endif %}
 COPY "{{ Path.Version }}/startup/launcher" /startup/launcher
 COPY "{{ Path.Version }}/startup/base" /startup/base
 COPY "{{ Path.Version }}/startup/supervisord.conf" /etc/supervisor/supervisord.conf
 {%- if Image.Variant != "Minimal" %}
-{%- if not Image.IsDevelopmentVersion %}
+{%- if not rootless_support %}
 COPY "{{ Path.Version }}/startup/user-provisioning" /startup/user-provisioning
 {%- endif %}
 COPY --chmod=600 "{{ Path.Version }}/conf/sssd/sssd.conf" /etc/sssd/sssd.conf
-{%- if Image.IsDevelopmentVersion %}
+{%- if rootless_support %}
 COPY "{{ Path.Version }}/startup/user-provisioning/sssd.conf" /opt/startup-templates/sssd.conf
 {%- endif %}
 {%- endif %}
@@ -113,7 +117,7 @@ COPY "{{ Path.Version }}/conf/jupyter/*" "{{ Path.Version }}/conf/launcher/*" "{
 
 ### Configure Workbench ###
 RUN mkdir -p /var/lib/rstudio-server/monitor/log \
-{%- if Image.IsDevelopmentVersion %}
+{%- if rootless_support %}
                /var/lib/rstudio-server/conf \
                /var/lib/rstudio-server/body \
                /var/lib/rstudio-server/proxy \
@@ -159,7 +163,7 @@ EXPOSE 8787/tcp
 EXPOSE 5559/tcp
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
     CMD curl -fsS http://localhost:8787/health-check || exit 1
-{%- if Image.IsDevelopmentVersion and Image.Variant != "Minimal" %}
+{%- if rootless_support and Image.Variant != "Minimal" %}
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 {%- endif %}
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/workbench/template/startup/supervisord.conf.jinja2
+++ b/workbench/template/startup/supervisord.conf.jinja2
@@ -1,5 +1,9 @@
 ; supervisor config file
-{%- if Image.IsDevelopmentVersion %}
+{%- set version_parts = Image.Version.split('.') %}
+{%- set rootless_support = Image.IsDevelopmentVersion
+    or (version_parts[0] | int > 2026)
+    or (version_parts[0] | int == 2026 and version_parts[1] | int >= 6) %}
+{%- if rootless_support %}
 {%- set supervisor_socket = "/var/run/supervisor/supervisor.sock" %}
 {%- set supervisor_pidfile = "/var/run/supervisor/supervisord.pid" %}
 {%- else %}
@@ -13,7 +17,7 @@ chmod=0700                       ; sockef file mode (default 0700)
 
 [supervisord]
 logfile=/dev/stdout ; (main log file;default $CWD/supervisord.log)
-{%- if not Image.IsDevelopmentVersion %}
+{%- if not rootless_support %}
 user=root
 {%- endif %}
 pidfile={{ supervisor_pidfile }} ; (supervisord pidfile;default supervisord.pid)

--- a/workbench/template/test/goss.yaml.jinja2
+++ b/workbench/template/test/goss.yaml.jinja2
@@ -4,18 +4,22 @@ Bakery handles bootstrapping the files into template rendering.
 -#}
 {%- import "python.j2" as python -%}
 {%- import "r.j2" as r -%}
+{%- set version_parts = Image.Version.split('.') -%}
+{%- set rootless_support = Image.IsDevelopmentVersion
+    or (version_parts[0] | int > 2026)
+    or (version_parts[0] | int == 2026 and version_parts[1] | int >= 6) -%}
 user:
   rstudio-server:
     exists: true
     uid: 999
-    gid: {% if Image.IsDevelopmentVersion %}999{% else %}{% raw %}{{ if and (eq .Env.IMAGE_VARIANT "Standard") (and (eq .Env.IMAGE_OS_NAME "ubuntu") (eq .Env.IMAGE_OS_VERSION "24.04")) }}997{{ else }}999{{ end }}{% endraw %}{% endif %}
+    gid: {% if rootless_support %}999{% else %}{% raw %}{{ if and (eq .Env.IMAGE_VARIANT "Standard") (and (eq .Env.IMAGE_OS_NAME "ubuntu") (eq .Env.IMAGE_OS_VERSION "24.04")) }}997{{ else }}999{{ end }}{% endraw %}{% endif %}
     groups:
       - rstudio-server
 
 group:
   rstudio-server:
     exists: true
-    gid: {% if Image.IsDevelopmentVersion %}999{% else %}{% raw %}{{ if and (eq .Env.IMAGE_VARIANT "Standard") (and (eq .Env.IMAGE_OS_NAME "ubuntu") (eq .Env.IMAGE_OS_VERSION "24.04")) }}997{{ else }}999{{ end }}{% endraw %}{% endif %}
+    gid: {% if rootless_support %}999{% else %}{% raw %}{{ if and (eq .Env.IMAGE_VARIANT "Standard") (and (eq .Env.IMAGE_OS_NAME "ubuntu") (eq .Env.IMAGE_OS_VERSION "24.04")) }}997{{ else }}999{{ end }}{% endraw %}{% endif %}
 
 package:
   rstudio-server:
@@ -82,39 +86,46 @@ file:
   # Check for rstudio-launcher executable
   /usr/lib/rstudio-server/bin/rstudio-launcher:
     exists: true
-  {%- if Image.IsDevelopmentVersion %}
+  {%- if rootless_support %}
   # Check for rstudio-server runtime directories with correct ownership and setgid
   /var/lib/rstudio-server:
     exists: true
     owner: rstudio-server
     group: rstudio-server
+    gid: 999
     mode: "2775"
   /var/lib/rstudio-server/monitor/log:
     exists: true
     owner: rstudio-server
     group: rstudio-server
+    gid: 999
   /var/lib/rstudio-server/conf:
     exists: true
     owner: rstudio-server
     group: rstudio-server
+    gid: 999
   /var/lib/rstudio-server/body:
     exists: true
     owner: rstudio-server
     group: rstudio-server
+    gid: 999
   /var/lib/rstudio-server/proxy:
     exists: true
     owner: rstudio-server
     group: rstudio-server
+    gid: 999
   # rstudio-launcher resets its scratch directory to 0755 on startup, so we
   # only assert ownership here; the build-time setgid mode does not survive.
   /var/lib/rstudio-launcher:
     exists: true
     owner: rstudio-server
     group: rstudio-server
+    gid: 999
   /var/log/rstudio:
     exists: true
     owner: rstudio-server
     group: rstudio-server
+    gid: 999
     mode: "2775"
   /var/run/rstudio-server:
     exists: true
@@ -123,6 +134,7 @@ file:
     exists: true
     owner: rstudio-server
     group: rstudio-server
+    gid: 999
     mode: "2775"
   {%- else %}
   # Check for rstudio-server monitor log directory
@@ -158,7 +170,7 @@ file:
     owner: root
     group: root
     mode: "0600"
-  {%- if Image.IsDevelopmentVersion %}
+  {%- if rootless_support %}
   # sssd supervisord program is staged here; entrypoint installs it at runtime when root
   /opt/startup-templates/sssd.conf:
     exists: {% raw %}{{ if eq .Env.IMAGE_VARIANT "Standard" }}true{{ else }}false{{ end }}{% endraw %}
@@ -245,7 +257,7 @@ file:
 
 command:
   "Ensure rstudio-server has permissions to log directory":
-    exec: {% if Image.IsDevelopmentVersion %}sudo -u rstudio-server touch /var/lib/rstudio-server/monitor/log/rstudio-server.log{% else %}su rstudio-server -c 'touch /var/lib/rstudio-server/monitor/log/rstudio-server.log'{% endif %}
+    exec: {% if rootless_support %}sudo -u rstudio-server touch /var/lib/rstudio-server/monitor/log/rstudio-server.log{% else %}su rstudio-server -c 'touch /var/lib/rstudio-server/monitor/log/rstudio-server.log'{% endif %}
     exit-status: 0
   "Ensure server log can be created":
     exec: touch /var/log/rstudio-server.log


### PR DESCRIPTION
## Summary
- Replace the dev-only `Image.IsDevelopmentVersion` gate with a version-floor check (`rootless_support`, true for `Image.IsDevelopmentVersion` or version >= 2026.06) so the rstudio-server uid/gid 999 pinning, runtime directory setup, sssd/entrypoint staging, and non-root supervisord plumbing from #116 apply to real releases starting at 2026.06 instead of disappearing once a dev preview becomes an official release.
- Re-render the already-published `workbench/2026.06/` version directory to pick up the change (other version directories are untouched and verified byte-identical on re-render).
- Extend the goss tests with explicit numeric `gid: 999` assertions on the rootless runtime directories, in addition to the existing name-based `group: rstudio-server` checks.
- Fix the "Ensure rstudio-server has permissions to log directory" goss command to use `sudo -u rstudio-server` instead of `su rstudio-server -c` when `rootless_support` is true — discovered via a real build/test run that `su` fails because the precreated rstudio-server user has `/usr/sbin/nologin` as its shell.

## Test plan
- [x] Re-rendered `workbench/2026.06/*` via `bakery update files` and confirmed `2025.09`, `2026.01`, `2026.04`, `2026.05` render byte-identical (version-floor check correctly excludes them)
- [x] Built `workbench:2026.06.0` Standard and Minimal Ubuntu 24.04 images via `bakery build`
- [x] Ran `bakery dgoss run` against the built images — Standard 168/168 passed, Minimal 101/101 passed (28 skipped), including the new gid assertions and the sudo/su fix