### PR TITLE
Improve layer-cache reuse across Workbench releases

### DIFF
--- a/workbench/2026.05/Containerfile.ubuntu2204.min
+++ b/workbench/2026.05/Containerfile.ubuntu2204.min
@@ -5,7 +5,6 @@ LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:22.04"
 ARG DEBIAN_FRONTEND=noninteractive
 ARG BUILDARCH
 ARG TARGETARCH=${BUILDARCH}
-ARG WORKBENCH_VERSION="2026.05.1+225.pro10"
 ARG RSTUDIO_INSTALL_NO_LICENSE_INITIALIZATION=1
 
 ENV PWB_STARTUP_DEBUG=0
@@ -49,6 +48,7 @@ RUN apt-get update -yqq && \
 COPY --chmod=0755 workbench/scripts/wait-for-it.sh /usr/local/bin/wait-for-it.sh
 
 ### Install Workbench 2026.05.1+225.pro10 ###
+ARG WORKBENCH_VERSION="2026.05.1+225.pro10"
 COPY --chmod=0755 workbench/2026.05/scripts/install_workbench.sh /tmp/install_workbench.sh
 RUN \
     /tmp/install_workbench.sh && \
@@ -56,8 +56,6 @@ RUN \
 
 ### Install Quarto to PATH ###
 RUN ln -s /lib/rstudio-server/bin/quarto/bin/quarto /usr/local/bin/quarto
-
-
 
 ### Copy startup scripts ###
 COPY --chmod=0775 "workbench/2026.05/scripts/startup.sh" /usr/local/bin/startup.sh

--- a/workbench/2026.05/Containerfile.ubuntu2204.std
+++ b/workbench/2026.05/Containerfile.ubuntu2204.std
@@ -15,7 +15,6 @@ LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:22.04"
 ARG DEBIAN_FRONTEND=noninteractive
 ARG BUILDARCH
 ARG TARGETARCH=${BUILDARCH}
-ARG WORKBENCH_VERSION="2026.05.1+225.pro10"
 ARG RSTUDIO_INSTALL_NO_LICENSE_INITIALIZATION=1
 
 ENV PWB_STARTUP_DEBUG=0
@@ -61,15 +60,6 @@ RUN apt-get update -yqq && \
 ### Install wait-for-it ###
 COPY --chmod=0755 workbench/scripts/wait-for-it.sh /usr/local/bin/wait-for-it.sh
 
-### Install Workbench 2026.05.1+225.pro10 ###
-COPY --chmod=0755 workbench/2026.05/scripts/install_workbench.sh /tmp/install_workbench.sh
-RUN \
-    /tmp/install_workbench.sh && \
-    rm -f /tmp/install_workbench.sh
-
-### Install Quarto to PATH ###
-RUN ln -s /lib/rstudio-server/bin/quarto/bin/quarto /usr/local/bin/quarto
-
 ### Install R ###
 RUN RUN_UNATTENDED=1 R_VERSION=4.6.0 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \
     find . -type f -name '[rR]-4.6.0.*\.(deb|rpm)' -delete
@@ -101,6 +91,16 @@ RUN apt-get update -yqq && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/*
 RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
+
+### Install Workbench 2026.05.1+225.pro10 ###
+ARG WORKBENCH_VERSION="2026.05.1+225.pro10"
+COPY --chmod=0755 workbench/2026.05/scripts/install_workbench.sh /tmp/install_workbench.sh
+RUN \
+    /tmp/install_workbench.sh && \
+    rm -f /tmp/install_workbench.sh
+
+### Install Quarto to PATH ###
+RUN ln -s /lib/rstudio-server/bin/quarto/bin/quarto /usr/local/bin/quarto
 
 ### Copy startup scripts ###
 COPY --chmod=0775 "workbench/2026.05/scripts/startup.sh" /usr/local/bin/startup.sh

--- a/workbench/2026.05/Containerfile.ubuntu2404.min
+++ b/workbench/2026.05/Containerfile.ubuntu2404.min
@@ -5,7 +5,6 @@ LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04"
 ARG DEBIAN_FRONTEND=noninteractive
 ARG BUILDARCH
 ARG TARGETARCH=${BUILDARCH}
-ARG WORKBENCH_VERSION="2026.05.1+225.pro10"
 ARG RSTUDIO_INSTALL_NO_LICENSE_INITIALIZATION=1
 
 ENV PWB_STARTUP_DEBUG=0
@@ -49,6 +48,7 @@ RUN apt-get update -yqq && \
 COPY --chmod=0755 workbench/scripts/wait-for-it.sh /usr/local/bin/wait-for-it.sh
 
 ### Install Workbench 2026.05.1+225.pro10 ###
+ARG WORKBENCH_VERSION="2026.05.1+225.pro10"
 COPY --chmod=0755 workbench/2026.05/scripts/install_workbench.sh /tmp/install_workbench.sh
 RUN \
     /tmp/install_workbench.sh && \
@@ -56,8 +56,6 @@ RUN \
 
 ### Install Quarto to PATH ###
 RUN ln -s /lib/rstudio-server/bin/quarto/bin/quarto /usr/local/bin/quarto
-
-
 
 ### Copy startup scripts ###
 COPY --chmod=0775 "workbench/2026.05/scripts/startup.sh" /usr/local/bin/startup.sh

--- a/workbench/2026.05/Containerfile.ubuntu2404.std
+++ b/workbench/2026.05/Containerfile.ubuntu2404.std
@@ -15,7 +15,6 @@ LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04"
 ARG DEBIAN_FRONTEND=noninteractive
 ARG BUILDARCH
 ARG TARGETARCH=${BUILDARCH}
-ARG WORKBENCH_VERSION="2026.05.1+225.pro10"
 ARG RSTUDIO_INSTALL_NO_LICENSE_INITIALIZATION=1
 
 ENV PWB_STARTUP_DEBUG=0
@@ -61,15 +60,6 @@ RUN apt-get update -yqq && \
 ### Install wait-for-it ###
 COPY --chmod=0755 workbench/scripts/wait-for-it.sh /usr/local/bin/wait-for-it.sh
 
-### Install Workbench 2026.05.1+225.pro10 ###
-COPY --chmod=0755 workbench/2026.05/scripts/install_workbench.sh /tmp/install_workbench.sh
-RUN \
-    /tmp/install_workbench.sh && \
-    rm -f /tmp/install_workbench.sh
-
-### Install Quarto to PATH ###
-RUN ln -s /lib/rstudio-server/bin/quarto/bin/quarto /usr/local/bin/quarto
-
 ### Install R ###
 RUN RUN_UNATTENDED=1 R_VERSION=4.6.0 bash -c "$(curl -fsSL https://rstd.io/r-install)" && \
     find . -type f -name '[rR]-4.6.0.*\.(deb|rpm)' -delete
@@ -101,6 +91,16 @@ RUN apt-get update -yqq && \
     apt-get clean -yqq && \
     rm -rf /var/lib/apt/lists/*
 RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
+
+### Install Workbench 2026.05.1+225.pro10 ###
+ARG WORKBENCH_VERSION="2026.05.1+225.pro10"
+COPY --chmod=0755 workbench/2026.05/scripts/install_workbench.sh /tmp/install_workbench.sh
+RUN \
+    /tmp/install_workbench.sh && \
+    rm -f /tmp/install_workbench.sh
+
+### Install Quarto to PATH ###
+RUN ln -s /lib/rstudio-server/bin/quarto/bin/quarto /usr/local/bin/quarto
 
 ### Copy startup scripts ###
 COPY --chmod=0775 "workbench/2026.05/scripts/startup.sh" /usr/local/bin/startup.sh

--- a/workbench/template/Containerfile.ubuntu2204.jinja2
+++ b/workbench/template/Containerfile.ubuntu2204.jinja2
@@ -19,7 +19,6 @@ LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:22.04"
 ARG DEBIAN_FRONTEND=noninteractive
 ARG BUILDARCH
 ARG TARGETARCH=${BUILDARCH}
-ARG WORKBENCH_VERSION="{{ Image.Version }}"
 ARG RSTUDIO_INSTALL_NO_LICENSE_INITIALIZATION=1
 
 ENV PWB_STARTUP_DEBUG=0
@@ -61,15 +60,6 @@ COPY {{ Path.Version }}/deps/ubuntu-22.04_packages.txt /tmp/packages.txt
 ### Install wait-for-it ###
 COPY --chmod=0755 {{ Path.Image }}/scripts/wait-for-it.sh /usr/local/bin/wait-for-it.sh
 
-### Install Workbench {{ Image.Version }} ###
-COPY --chmod=0755 {{ Path.Version }}/scripts/install_workbench.sh /tmp/install_workbench.sh
-RUN {% if Image.DownloadURL is defined %}DOWNLOAD_URL="{{ Image.DownloadURL }}" {% endif %}\
-    /tmp/install_workbench.sh && \
-    rm -f /tmp/install_workbench.sh
-
-### Install Quarto to PATH ###
-RUN ln -s /lib/rstudio-server/bin/quarto/bin/quarto /usr/local/bin/quarto
-
 {% if not Image.Variant == "Minimal" -%}
 ### Install R ###
 {{ r.run_install(Dependencies.R) }}
@@ -90,7 +80,18 @@ RUN {{ python.install_packages(python_version, "ipykernel") }} && \
 ### Install Pro Drivers ###
 {{ apt.run_install(packages="rstudio-drivers") }}
 RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
-{%- endif %}
+
+{% endif -%}
+
+### Install Workbench {{ Image.Version }} ###
+ARG WORKBENCH_VERSION="{{ Image.Version }}"
+COPY --chmod=0755 {{ Path.Version }}/scripts/install_workbench.sh /tmp/install_workbench.sh
+RUN {% if Image.DownloadURL is defined %}DOWNLOAD_URL="{{ Image.DownloadURL }}" {% endif %}\
+    /tmp/install_workbench.sh && \
+    rm -f /tmp/install_workbench.sh
+
+### Install Quarto to PATH ###
+RUN ln -s /lib/rstudio-server/bin/quarto/bin/quarto /usr/local/bin/quarto
 
 ### Copy startup scripts ###
 COPY --chmod=0775 "{{ Path.Version }}/scripts/startup.sh" /usr/local/bin/startup.sh

--- a/workbench/template/Containerfile.ubuntu2404.jinja2
+++ b/workbench/template/Containerfile.ubuntu2404.jinja2
@@ -19,7 +19,6 @@ LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04"
 ARG DEBIAN_FRONTEND=noninteractive
 ARG BUILDARCH
 ARG TARGETARCH=${BUILDARCH}
-ARG WORKBENCH_VERSION="{{ Image.Version }}"
 ARG RSTUDIO_INSTALL_NO_LICENSE_INITIALIZATION=1
 
 ENV PWB_STARTUP_DEBUG=0
@@ -61,15 +60,6 @@ COPY {{ Path.Version }}/deps/ubuntu-24.04_packages.txt /tmp/packages.txt
 ### Install wait-for-it ###
 COPY --chmod=0755 {{ Path.Image }}/scripts/wait-for-it.sh /usr/local/bin/wait-for-it.sh
 
-### Install Workbench {{ Image.Version }} ###
-COPY --chmod=0755 {{ Path.Version }}/scripts/install_workbench.sh /tmp/install_workbench.sh
-RUN {% if Image.DownloadURL is defined %}DOWNLOAD_URL="{{ Image.DownloadURL }}" {% endif %}\
-    /tmp/install_workbench.sh && \
-    rm -f /tmp/install_workbench.sh
-
-### Install Quarto to PATH ###
-RUN ln -s /lib/rstudio-server/bin/quarto/bin/quarto /usr/local/bin/quarto
-
 {% if not Image.Variant == "Minimal" -%}
 ### Install R ###
 {{ r.run_install(Dependencies.R) }}
@@ -90,7 +80,18 @@ RUN {{ python.install_packages(python_version, "ipykernel") }} && \
 ### Install Pro Drivers ###
 {{ apt.run_install(packages="rstudio-drivers") }}
 RUN cp /opt/rstudio-drivers/odbcinst.ini.sample /etc/odbcinst.ini
-{%- endif %}
+
+{% endif -%}
+
+### Install Workbench {{ Image.Version }} ###
+ARG WORKBENCH_VERSION="{{ Image.Version }}"
+COPY --chmod=0755 {{ Path.Version }}/scripts/install_workbench.sh /tmp/install_workbench.sh
+RUN {% if Image.DownloadURL is defined %}DOWNLOAD_URL="{{ Image.DownloadURL }}" {% endif %}\
+    /tmp/install_workbench.sh && \
+    rm -f /tmp/install_workbench.sh
+
+### Install Quarto to PATH ###
+RUN ln -s /lib/rstudio-server/bin/quarto/bin/quarto /usr/local/bin/quarto
 
 ### Copy startup scripts ###
 COPY --chmod=0775 "{{ Path.Version }}/scripts/startup.sh" /usr/local/bin/startup.sh


### PR DESCRIPTION
Every Workbench release rebuilds R, Python, Jupyter, and the Pro Drivers, because the version-pinned install ran before them and the version `ARG` sat at the top — defeating CI's registry layer cache. Moving those version-invariant installs ahead of the install lets them be reused across releases; Quarto and TinyTeX stay after it (Quarto is bundled by Workbench, TinyTeX uses it), so only those still rebuild.
