### PR TITLE
Fix libnss_pwb symlink deletion by ldconfig during R install

### DIFF
--- a/workbench-session/matrix/Containerfile.ubuntu2204
+++ b/workbench-session/matrix/Containerfile.ubuntu2204
@@ -63,6 +63,8 @@ RUN case "${TARGETARCH}" in \
       arm64) TRIPLET=aarch64-linux-gnu ;; \
       *) echo "unsupported arch ${TARGETARCH}"; exit 1 ;; \
     esac && \
+    mkdir -p /usr/lib/rstudio-server/bin/jammy && \
+    touch /usr/lib/rstudio-server/bin/jammy/libnss_pwb.so && \
     ln -sf /usr/lib/rstudio-server/bin/jammy/libnss_pwb.so \
            "/usr/lib/${TRIPLET}/libnss_pwb.so.2" && \
     for db in passwd group shadow; do \

--- a/workbench-session/matrix/Containerfile.ubuntu2404
+++ b/workbench-session/matrix/Containerfile.ubuntu2404
@@ -63,6 +63,8 @@ RUN case "${TARGETARCH}" in \
       arm64) TRIPLET=aarch64-linux-gnu ;; \
       *) echo "unsupported arch ${TARGETARCH}"; exit 1 ;; \
     esac && \
+    mkdir -p /usr/lib/rstudio-server/bin/noble && \
+    touch /usr/lib/rstudio-server/bin/noble/libnss_pwb.so && \
     ln -sf /usr/lib/rstudio-server/bin/noble/libnss_pwb.so \
            "/usr/lib/${TRIPLET}/libnss_pwb.so.2" && \
     for db in passwd group shadow; do \

--- a/workbench-session/matrix/test/goss.yaml
+++ b/workbench-session/matrix/test/goss.yaml
@@ -89,5 +89,5 @@ command:
     exec: 'find /opt -type d -not -perm -005 -print 2>&1 | head -c1 | (! grep -q .)'
     exit-status: 0
   "Verify libnss_pwb symlink is present for current architecture":
-    exec: 'dpkg-architecture -qDEB_HOST_MULTIARCH | xargs -I{} test -L "/usr/lib/{}/libnss_pwb.so.2"'
+    exec: 'TRIPLET=$(case "$(uname -m)" in x86_64) echo x86_64-linux-gnu ;; aarch64) echo aarch64-linux-gnu ;; *) echo "unsupported arch $(uname -m)" >&2; exit 1 ;; esac) && test -L "/usr/lib/${TRIPLET}/libnss_pwb.so.2"'
     exit-status: 0

--- a/workbench-session/template/Containerfile.ubuntu2204.jinja2
+++ b/workbench-session/template/Containerfile.ubuntu2204.jinja2
@@ -44,6 +44,8 @@ RUN case "${TARGETARCH}" in \
       arm64) TRIPLET=aarch64-linux-gnu ;; \
       *) echo "unsupported arch ${TARGETARCH}"; exit 1 ;; \
     esac && \
+    mkdir -p /usr/lib/rstudio-server/bin/jammy && \
+    touch /usr/lib/rstudio-server/bin/jammy/libnss_pwb.so && \
     ln -sf /usr/lib/rstudio-server/bin/jammy/libnss_pwb.so \
            "/usr/lib/${TRIPLET}/libnss_pwb.so.2" && \
     for db in passwd group shadow; do \

--- a/workbench-session/template/Containerfile.ubuntu2404.jinja2
+++ b/workbench-session/template/Containerfile.ubuntu2404.jinja2
@@ -44,6 +44,8 @@ RUN case "${TARGETARCH}" in \
       arm64) TRIPLET=aarch64-linux-gnu ;; \
       *) echo "unsupported arch ${TARGETARCH}"; exit 1 ;; \
     esac && \
+    mkdir -p /usr/lib/rstudio-server/bin/noble && \
+    touch /usr/lib/rstudio-server/bin/noble/libnss_pwb.so && \
     ln -sf /usr/lib/rstudio-server/bin/noble/libnss_pwb.so \
            "/usr/lib/${TRIPLET}/libnss_pwb.so.2" && \
     for db in passwd group shadow; do \

--- a/workbench-session/template/test/goss.yaml.jinja2
+++ b/workbench-session/template/test/goss.yaml.jinja2
@@ -96,5 +96,5 @@ command:
     exec: 'find /opt -type d -not -perm -005 -print 2>&1 | head -c1 | (! grep -q .)'
     exit-status: 0
   "Verify libnss_pwb symlink is present for current architecture":
-    exec: 'dpkg-architecture -qDEB_HOST_MULTIARCH | xargs -I{} test -L "/usr/lib/{}/libnss_pwb.so.2"'
+    exec: 'TRIPLET=$(case "$(uname -m)" in x86_64) echo x86_64-linux-gnu ;; aarch64) echo aarch64-linux-gnu ;; *) echo "unsupported arch $(uname -m)" >&2; exit 1 ;; esac) && test -L "/usr/lib/${TRIPLET}/libnss_pwb.so.2"'
     exit-status: 0


### PR DESCRIPTION
## Summary
- Create a placeholder regular file at the `libnss_pwb.so` symlink target before creating the symlink in the `workbench-session` Containerfile templates (22.04/24.04), so `ldconfig`'s postinst trigger during the R install sees an existing (empty) target instead of a fully dangling one and no longer deletes the symlink.
- Fix the corresponding goss test, which relied on `dpkg-architecture` and vacuously passed on the Minimal variant (no `dpkg-dev`); it now computes the multiarch triplet via `uname -m` so the assertion actually runs on every variant.

Fixes #160

## Test plan
- [x] Repro'd the original bug and the fix in a bare `ubuntu:24.04` container: symlink is deleted by `ldconfig` during a real R install without the fix, and survives with the fix.
- [x] Verified the updated goss `exec` check fails when the symlink is absent and passes when present, without depending on `dpkg-architecture`/`dpkg-dev`.
- [ ] CI `dgoss run` on `workbench-session` matrix images

🤖 Generated with [Claude Code](https://claude.com/claude-code)