### PR TITLE
[DNM] Test images-shared feat/parallel-build-calls

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,6 +57,7 @@ jobs:
       packages: write
     uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@feat/parallel-build-calls
     with:
+      version: "feat/parallel-build-calls"
       dev-versions: "exclude"
       matrix-versions: "exclude"
 
@@ -67,6 +68,7 @@ jobs:
       packages: write
     uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@feat/parallel-build-calls
     with:
+      version: "feat/parallel-build-calls"
       dev-versions: "only"
       matrix-versions: "include"
 
@@ -77,6 +79,7 @@ jobs:
       packages: write
     uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@feat/parallel-build-calls
     with:
+      version: "feat/parallel-build-calls"
       matrix-versions: "only"
 
   zizmor:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,7 +55,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
+    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@feat/parallel-build-calls
     with:
       dev-versions: "exclude"
       matrix-versions: "exclude"
@@ -65,7 +65,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
+    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@feat/parallel-build-calls
     with:
       dev-versions: "only"
       matrix-versions: "include"
@@ -75,7 +75,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@main
+    uses: posit-dev/images-shared/.github/workflows/bakery-build-pr.yml@feat/parallel-build-calls
     with:
       matrix-versions: "only"
 


### PR DESCRIPTION
## Summary
- Retargets the `bakery-build-pr.yml` reusable workflow calls in `pr.yml` (production, development, session jobs) from `images-shared@main` to `images-shared@feat/parallel-build-calls`
- Purpose: exercise the parallel build calls feature in CI before it merges upstream

## Do not merge
This is a throwaway branch to validate the images-shared feature branch. Revert once testing is done.

## Test plan
- [ ] Confirm CI runs against `images-shared@feat/parallel-build-calls`
- [ ] Confirm production/development/session jobs behave as expected with parallel build calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)