### PR TITLE
Test images-shared PR #668 release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,25 +9,12 @@ on:
 
 
 jobs:
-  # Jobs that call a reusable workflow via `uses:` can't also set
-  # `environment:`, so the branch restriction lives in its own job and
-  # release depends on it.
-  main-only:
-    name: Main Only
-    runs-on: ubuntu-latest
-    permissions: {}
-    environment: production
-    steps:
-      - run: echo "Branch allowed by environment policy."
-
   release:
-    needs:
-      - main-only
     if: github.event_name == 'workflow_dispatch'
     permissions:
       contents: write
       pull-requests: write
-    uses: posit-dev/images-shared/.github/workflows/product-release.yml@main
+    uses: posit-dev/images-shared/.github/workflows/product-release.yml@feat/release-pr-diff-link
     with:
       version: ${{ inputs.version }}
       images: "workbench workbench-session-init"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
 
   trigger-specialized:
     needs: release
+    # Disabled for this test branch to avoid cascading a real release into
+    # images-specialized. Remove this line when testing is done.
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
Temporary branch to exercise the release workflow changes from posit-dev/images-shared#668 (version-diff PR comments) via workflow_dispatch.

Removes the main-only environment gate and points the release job at the feat/release-pr-diff-link branch instead of main. Also disables trigger-specialized so this test run doesn't cascade a real release into images-specialized.

Not intended to merge — revert or close once testing is complete.

- https://github.com/posit-dev/images-shared/pull/668