### PR TITLE
Drop shared-run assertion from session-init goss

### DIFF
--- a/workbench-session-init/template/test/goss.yaml.jinja2
+++ b/workbench-session-init/template/test/goss.yaml.jinja2
@@ -55,10 +55,6 @@ file:
     filetype: directory
     mode: "0755"
   {% raw %}{{- end }}{% endraw %}
-  /opt/session-components/bin/shared-run:
-    exists: true
-    filetype: file
-    mode: "0755"
   /opt/session-components/R:
     exists: true
     filetype: directory


### PR DESCRIPTION
## Summary

Removes the `/opt/session-components/bin/shared-run` file assertion from the `workbench-session-init` goss template.

The session components binary no longer ships a `shared-run` executable at `/opt/session-components/bin/shared-run`, so the assertion fails during test. This drops the check from the template.

## Open question: re-rendering strategy

This change only edits the template (`workbench-session-init/template/test/goss.yaml.jinja2`). It intentionally does **not** run `bakery update files`, so the rendered version directories (`2025.09` … `2026.07`) still contain the `shared-run` assertion.

The `shared-run` binary only stops shipping starting with the `08` build, so re-rendering all versions unconditionally would incorrectly drop the assertion from earlier versions that still ship it.

I'd like reviewer input on how we want to handle this going forward. Options include:

- Gate the assertion in the template on `Image.Version` so re-rendering produces the correct result per version, then re-render.
- Only re-render the affected (`08`+) versions and leave earlier rendered files untouched.
- Something else.

## Test plan

- `bakery dgoss run --image-name workbench-session-init`