### PR TITLE
Point temp-registry at ECR in build workflows

### DIFF
--- a/.github/workflows/development-positron.yml
+++ b/.github/workflows/development-positron.yml
@@ -70,6 +70,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
 
     uses: "posit-dev/images-shared/.github/workflows/bakery-build-native.yml@main"
     secrets:

--- a/.github/workflows/development-positron.yml
+++ b/.github/workflows/development-positron.yml
@@ -72,12 +72,15 @@ jobs:
       packages: write
 
     uses: "posit-dev/images-shared/.github/workflows/bakery-build-native.yml@main"
+    secrets:
+      AWS_ROLE: ${{ secrets.AWS_ROLE }}
     with:
       dev-versions: "only"
       matrix-versions: "include"
       image-name: "^workbench-positron-init$"
       dev-version: ${{ inputs.version }}
       dev-channel: ${{ inputs.channel }}
+      temp-registry: "565037064999.dkr.ecr.us-east-2.amazonaws.com/images"
       # Forward the cache input. For non-workflow_dispatch events (schedule / push),
       # `inputs.cache` is unset, so default to true (preserves prior behavior). Only
       # an explicit workflow_dispatch with `cache: false` disables the registry cache.

--- a/.github/workflows/development-workbench.yml
+++ b/.github/workflows/development-workbench.yml
@@ -75,6 +75,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
 
     uses: "posit-dev/images-shared/.github/workflows/bakery-build-native.yml@main"
     secrets:

--- a/.github/workflows/development-workbench.yml
+++ b/.github/workflows/development-workbench.yml
@@ -77,6 +77,8 @@ jobs:
       packages: write
 
     uses: "posit-dev/images-shared/.github/workflows/bakery-build-native.yml@main"
+    secrets:
+      AWS_ROLE: ${{ secrets.AWS_ROLE }}
     with:
       dev-versions: "only"
       matrix-versions: "exclude"
@@ -85,6 +87,7 @@ jobs:
       dev-version: ${{ inputs.version }}
       dev-channel: ${{ inputs.channel }}
       release-branch: ${{ inputs.release-branch }}
+      temp-registry: "565037064999.dkr.ecr.us-east-2.amazonaws.com/images"
       # Forward the cache input. For non-workflow_dispatch events (schedule / push),
       # `inputs.cache` is unset, so default to true (preserves prior behavior). Only
       # an explicit workflow_dispatch with `cache: false` disables the registry cache.

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -67,6 +67,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
 
     uses: "posit-dev/images-shared/.github/workflows/bakery-build-native.yml@main"
     secrets:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -73,9 +73,11 @@ jobs:
       DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       DOCKER_HUB_README_USERNAME: ${{ secrets.DOCKER_HUB_README_USERNAME }}
       DOCKER_HUB_README_PASSWORD: ${{ secrets.DOCKER_HUB_README_PASSWORD }}
+      AWS_ROLE: ${{ secrets.AWS_ROLE }}
     with:
       dev-versions: "exclude"
       matrix-versions: "exclude"
+      temp-registry: "565037064999.dkr.ecr.us-east-2.amazonaws.com/images"
       # Push images only for merges into main and weekly schduled re-builds.
       push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}
 

--- a/.github/workflows/session.yml
+++ b/.github/workflows/session.yml
@@ -55,7 +55,9 @@ jobs:
       DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       DOCKER_HUB_README_USERNAME: ${{ secrets.DOCKER_HUB_README_USERNAME }}
       DOCKER_HUB_README_PASSWORD: ${{ secrets.DOCKER_HUB_README_PASSWORD }}
+      AWS_ROLE: ${{ secrets.AWS_ROLE }}
     with:
       matrix-versions: only
+      temp-registry: "565037064999.dkr.ecr.us-east-2.amazonaws.com/images"
       # Push images only for merges into main and weekly schduled re-builds.
       push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/session.yml
+++ b/.github/workflows/session.yml
@@ -49,6 +49,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
 
     uses: "posit-dev/images-shared/.github/workflows/bakery-build-native.yml@main"
     secrets:


### PR DESCRIPTION
## Summary
This change redirects temporary image storage to ECR to reduce ratelimiting strain on GHCR. There is not functional change to the build except for where builds are placed in the interim.

- Add `temp-registry: 565037064999.dkr.ecr.us-east-2.amazonaws.com/images` to the `bakery-build-native.yml` calls in `development-workbench.yml`, `development-positron.yml`, `production.yml`, and `session.yml`
- Forward the `AWS_ROLE` secret (already present in this repo) to each of those calls

Refs posit-dev/images-shared#682

## Test plan
- [ ] `workflow_dispatch` run of each affected workflow succeeds and temp images land in the ECR repo